### PR TITLE
Fixing minor typo in code comments

### DIFF
--- a/ch-states/atoms-computation.ipynb
+++ b/ch-states/atoms-computation.ipynb
@@ -529,8 +529,8 @@
    "source": [
     "qc_ha = QuantumCircuit(4,2)\n",
     "# encode inputs in qubits 0 and 1\n",
-    "qc_ha.x(0) # For a=0, remove the this line. For a=1, leave it.\n",
-    "qc_ha.x(1) # For b=0, remove the this line. For b=1, leave it.\n",
+    "qc_ha.x(0) # For a=0, remove this line. For a=1, leave it.\n",
+    "qc_ha.x(1) # For b=0, remove this line. For b=1, leave it.\n",
     "qc_ha.barrier()\n",
     "# use cnots to write the XOR of the inputs on qubit 2\n",
     "qc_ha.cx(0,2)\n",


### PR DESCRIPTION
Removing unneeded `the` word in code comments to make the sentence clearer and coherent.