### PR TITLE
fixed issue 27 by updating satisfiability-grover.ipynb

### DIFF
--- a/ch-applications/satisfiability-grover.ipynb
+++ b/ch-applications/satisfiability-grover.ipynb
@@ -239,7 +239,7 @@
     "from qiskit import IBMQ\n",
     "IBMQ.load_accounts()\n",
     "\n",
-    "backend = IBMQ.get_backend('ibmq_16_melbourne')"
+    "backend = IBMQ.get_provider().get_backend('ibmq_16_melbourne')"
    ]
   },
   {


### PR DESCRIPTION
Fixed Issue #27 

IBMQ.get_backend()
is being deprecated.

So, edited IBMQ.get_backend() to ---
IBMQ.get_provider().get_backend()


Updating --->     qiskit-textbook/ch-applications/satisfiability-grover.ipynb
for link of https://community.qiskit.org/textbook/ch4/4.5.html
