### PR TITLE
Fix in equation of Matrix Exponential

### DIFF
--- a/ch-prerequisites/linear_algebra.ipynb
+++ b/ch-prerequisites/linear_algebra.ipynb
@@ -456,7 +456,7 @@
     "Substituting in all of this new information, we get:\n",
     "\n",
     "<br>\n",
-    "$$\\displaystyle\\sum_{n \\ = \\ 0}^{\\infty} \\ \\frac{(-1)^n \\gamma^{2n} B^{2n}}{(2n)!} \\ + \\ i \\displaystyle\\sum_{n \\ = \\ 0}^{\\infty} \\frac{(-1)^n \\gamma^{2n + 1} B^{2n + 1}}{(2n + 1)!} \\ = \\ \\mathbb{I} \\displaystyle\\sum_{n \\ = \\ 0}^{\\infty} \\ \\frac{(-1)^n \\gamma^{2n}}{(2n)!} \\ + \\ i B \\displaystyle\\sum_{n \\ = \\ 0}^{\\infty} \\frac{(-1)^n \\gamma^{2n + 1} B^{2n + 1}}{(2n + 1)!} \\ = \\ \\cos (\\gamma) \\mathbb{I} \\ + \\ i \\sin (\\gamma) B$$\n",
+    "$$\\displaystyle\\sum_{n \\ = \\ 0}^{\\infty} \\ \\frac{(-1)^n \\gamma^{2n} B^{2n}}{(2n)!} \\ + \\ i \\displaystyle\\sum_{n \\ = \\ 0}^{\\infty} \\frac{(-1)^n \\gamma^{2n + 1} B^{2n + 1}}{(2n + 1)!} \\ = \\ \\mathbb{I} \\displaystyle\\sum_{n \\ = \\ 0}^{\\infty} \\ \\frac{(-1)^n \\gamma^{2n}}{(2n)!} \\ + \\ i B \\displaystyle\\sum_{n \\ = \\ 0}^{\\infty} \\frac{(-1)^n \\gamma^{2n + 1}}{(2n + 1)!} \\ = \\ \\cos (\\gamma) \\mathbb{I} \\ + \\ i \\sin (\\gamma) B$$\n",
     "<br>\n",
     "\n",
     "We did it! This fact is **super** useful in quantum computation! Consider the Pauli matrices:\n",


### PR DESCRIPTION
When replacing the calculated values in the decomposition of the Involutory Matrix, you forgot to remove the replaced element in the sin part of the equation, it is just necessary to remove the factor from the equation before equalizing to sin and cos.