### PR TITLE
Erratum linear_algebra.ipynb Line 163

### DIFF
--- a/ch-prerequisites/linear_algebra.ipynb
+++ b/ch-prerequisites/linear_algebra.ipynb
@@ -160,7 +160,7 @@
     "\n",
     "Within quantum computation, we often deal with two very important types of matrices: **Hermitian** and **Unitary** matrices. The former is more important in the study of quantum mechanics, but is still definitely worth talking about in a study of quantum computation. The latter is of unparalleled importance in both quantum mechanics and quantum computation, if there is one concept that the reader should take away from this entire linear algebra section, it should be the idea of a unitary matrix.\n",
     "\n",
-    "Firstly, a Hermitian matrix is simply a matrix that is equal to its **conjugate transpose** (denoted with a $\\dagger$ symbol). This essentially means taking a matrix, flipping the sign in its imaginary components, and then reflecting the entries of the maatrix across its main diagonal (the diagonal that goes from the top left corner to the bottom right corner). For instance, a matrix that we commonly use in quantum computation, the Pauli-Y matrix is Hermitian:\n",
+    "Firstly, a Hermitian matrix is simply a matrix that is equal to its **conjugate transpose** (denoted with a $\\dagger$ symbol). This essentially means taking a matrix, flipping the sign in its imaginary components, and then reflecting the entries of the matrix across its main diagonal (the diagonal that goes from the top left corner to the bottom right corner). For instance, a matrix that we commonly use in quantum computation, the Pauli-Y matrix is Hermitian:\n",
     "\n",
     "<br>\n",
     "$$\\sigma_y \\ = \\ \\begin{pmatrix} 0 & -i \\\\ i & 0 \\end{pmatrix} \\ \\Rightarrow \\ \\sigma_y^{\\dagger} \\ = \\ \\begin{pmatrix} 0 & -(i) \\\\ -(-i) & 0 \\end{pmatrix} \\ = \\ \\begin{pmatrix} 0 & -i \\\\ i & 0 \\end{pmatrix} \\ = \\ \\sigma_y$$\n",


### PR DESCRIPTION
maatrix 
changed to
matrix.
Contextually Hermitian matrices are equivalent to their conjugate pair.