### PR TITLE
Erratum linear_algebra.ipynb Line 209

### DIFF
--- a/ch-prerequisites/linear_algebra.ipynb
+++ b/ch-prerequisites/linear_algebra.ipynb
@@ -206,7 +206,7 @@
     "\n",
     "Where each $f_i$ is some element of $F$. Now, if we have a set of vectors that spans a space, we are simply saying that **any other vector** in the vector space can be written as a linear combination of these vectors.\n",
     "\n",
-    "Now, we are in a position to define a **basis**, which is specific case of a spanning set, but first, we must talk about **linear dependence**. This is a fairly straightforward idea as well. A set of vectors $|v_1\\rangle, \\ ..., \\ |v_n\\rangle$ is said to be linearly dependent if there exist corresponding,  coefficients for each vector, $b_i \\ \\in \\ F$, such that:\n",
+    "Now, we are in a position to define a **basis**, which is a specific case of a spanning set, but first, we must talk about **linear dependence**. This is a fairly straightforward idea as well. A set of vectors $|v_1\\rangle, \\ ..., \\ |v_n\\rangle$ is said to be linearly dependent if there exist corresponding,  coefficients for each vector, $b_i \\ \\in \\ F$, such that:\n",
     "\n",
     "<br>\n",
     "$$b_1 |v_1\\rangle \\ + \\ b_2 |v_2\\rangle \\ + \\ ... \\ + \\ b_n |v_n\\rangle \\ = \\ \\displaystyle\\sum_{i} \\ b_i |v_i\\rangle \\ = \\ 0$$\n",


### PR DESCRIPTION
which is specific case
changed to
which is a specific case
Contextually a basis vector is a linearly independent vector spanning Rn.