### PR TITLE
fix(prerequisites-qiskit): fix typo

### DIFF
--- a/content/ch-prerequisites/qiskit.ipynb
+++ b/content/ch-prerequisites/qiskit.ipynb
@@ -687,7 +687,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To see this in action, here is a simple circuit. Note that, when making a measurement, we also refer to the bits in the classical index by register."
+    "To see this in action, here is a simple circuit. Note that, when making a measurement, we also refer to the bits in the classical register by index."
    ]
   },
   {


### PR DESCRIPTION
Changed

> we also refer to the bits in the classical index by register

to

> we also refer to the bits in the classical register by index