### PR TITLE
fixed a typo in documentation

### DIFF
--- a/content/ch-states/atoms-computation.ipynb
+++ b/content/ch-states/atoms-computation.ipynb
@@ -112,7 +112,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This circuit, which we have called `qc_output`, is created by Qiskit using `QuantumCircuit`. The number `n_q` defines the number of qubits in the circuit. With `n_b` we define he number of output bits we will extract from the circuit at the end.\n",
+    "This circuit, which we have called `qc_output`, is created by Qiskit using `QuantumCircuit`. The number `n_q` defines the number of qubits in the circuit. With `n_b` we define the number of output bits we will extract from the circuit at the end.\n",
     "\n",
     "The extraction of outputs in a quantum circuit is done using an operation called `measure`. Each measurement tells a specific qubit to give an output to a specific output bit. The following code adds a `measure` operation to each of our eight qubits. The qubits and bits are both labelled by the numbers from 0 to 7 (because that’s how programmers like to do things). The command `qc.measure(j,j)` adds a measurement to our circuit `qc` that tells qubit `j` to write an output to bit `j`."
    ]


### PR DESCRIPTION
there was a typo of " he " which should be " the ".

@delapuente @aasfaw 