### PR TITLE
Fix LaTeX display of composite gate matrix.

### DIFF
--- a/content/ch-gates/quantum-gates.ipynb
+++ b/content/ch-gates/quantum-gates.ipynb
@@ -259,7 +259,7 @@
     "        gate_latex += str(element) + '&'\n",
     "    gate_latex  = gate_latex[0:-1]\n",
     "    gate_latex +=  '\\\\\\\\'\n",
-    "gate_latex  = gate_latex[0:-4]\n",
+    "gate_latex  = gate_latex[0:-2]\n",
     "gate_latex += '\\end{pmatrix}'\n",
     "display(Markdown(gate_latex))"
    ]


### PR DESCRIPTION
The code `gate_latex[0:-4]` is presumably intended to remove the escaped double slashes `\\\\` at the end of the last row of the matrix, but only 2 characters need to be removed because the escape sequences are interpreted before the removal happens. The existing code also erroneously removes the final `0j` which should be displayed.

(It's very confusing because if you look at the raw notebook source code, each slash is escaped again resulting in a sequence of eight slashes `\\\\\\\\`!)