### PR TITLE
Update calibrating-qubits-openpulse.ipynb

### DIFF
--- a/content/ch-quantum-hardware/calibrating-qubits-openpulse.ipynb
+++ b/content/ch-quantum-hardware/calibrating-qubits-openpulse.ipynb
@@ -105,7 +105,7 @@
    ],
    "source": [
     "dt = backend_config.dt\n",
-    "print(f\"Sampling time: {dt*1e9} ns\")    # The configuration returns dt in nanoseconds"
+    "print(f\"Sampling time: {dt*1e9} ns\")    # The configuration returns dt in seconds"
    ]
   },
   {


### PR DESCRIPTION
Updated a comment to reflect that backends now report dt in seconds instead of nanoseconds. Code is unchanged.