### PR TITLE
Add issue template to Github Project

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,5 @@
+## Describe the Issue
+
+## Expected Solution
+
+## Anything else we should know?


### PR DESCRIPTION
Fixes #120.

This PR introduces an issue template. This template will be the default template shown to anyone creating a new issue. I have intentionally kept the issue template short and concise to ensure there is as little friction as possible for any first-time contributors.

I welcome any feedback on the issue template itself. 