### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
-## Description of Issue
+## Description of Issue (if Applicable)
 
 Fixes #your_issue_number_here
 
-## How Was This Issue Fixed?
+## What Changes Were Made?
 
 ## How Was This Tested?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description of Issue
+
+Fixes #your_issue_number_here
+
+## How Was This Issue Fixed?
+
+## How Was This Tested?
+
+Please provide any screenshots if applicable.
+
+## Anything Else We Should Know 


### PR DESCRIPTION
## Description of Issue

Fixes #121.

This project currently doesn't have a PR template. Without this PR template, maintainers may have a harder time understanding the PRs that are submitted by contributors. 

## How Was This Issue Fixed?
I added the `.github/pull_request_template.md` template which adds a PR template for each PR created in this Github project. This gives contributors a structured set of questions to answer as part of the PR process.

## How Was This Tested?
I was unable to test this as this will be first have to be merged into master before we can check to see if the PR template is applied to the Github project.  

## Anything Else We Should Know 
I welcome any feedback on the type of questions asked in the PR template. For reference, this PR utilizes the proposed PR template.