### PR TITLE
Update contributors .bib link in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The notebooks are compiled into html and exported to [the website](http://commun
 # Contributions
 Contributions of all types are always welcome. Please [start a pull request](https://help.github.com/en/articles/creating-a-pull-request) to submit changes, or create an issue to request updates.
 
-For a list of contributors, see the [.bib](https://github.com/Qiskit/qiskit-textbook/blob/master/qiskit-textbook.bib) file.
+For a list of contributors, see the [.bib](https://github.com/Qiskit/qiskit-textbook/blob/master/content/qiskit-textbook.bib) file.
 
 # License
 The materials and associated source code of this open-source textbook are licensed under [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
Fixes #126.

The Contributors .bib link is currently broken in the Readme.

This PR resolves this issue by updating the link to go to the proper page. To confirm this PR fixed the issue, I visited my [own forked repo](https://github.com/mrthankyou/qiskit-textbook/tree/126_fix_contributors_link), clicked on the .bib link, and was redirected to the correct page.