### PR TITLE
fixed typos

### DIFF
--- a/content/ch-states/atoms-computation.ipynb
+++ b/content/ch-states/atoms-computation.ipynb
@@ -292,7 +292,7 @@
    "source": [
     "Now our computer outputs the string ```10000000``` instead.\n",
     "\n",
-    "The bit we flipped, which comes from qubit 7, lives on the far left of the string. This is because Qiskit numbers the bits in a string from left to right. If this convention seems odd to you, don’t worry. It seems odd to lots of other people too, and some prefer to number their bits the other way around. But this system certainly has its advantages when we are using the bits to represent numbers. Specifically, it means that qubit 7 is telling us about how many $2^7$s we have in our number. So by flipping this bit, we’ve now written the number 128 in our simple 8-bit computer.\n",
+    "The bit we flipped, which comes from qubit 7, lives on the far left of the string. This is because Qiskit numbers the bits in a string from right to left. If this convention seems odd to you, don’t worry. It seems odd to lots of other people too, and some prefer to number their bits the other way around. But this system certainly has its advantages when we are using the bits to represent numbers. Specifically, it means that qubit 7 is telling us about how many $2^7$s we have in our number. So by flipping this bit, we’ve now written the number 128 in our simple 8-bit computer.\n",
     "\n",
     "Now try out writing another number for yourself. You could do your age, for example. Just use a search engine to find out what the number looks like in binary (if it includes a ‘0b’, just ignore it), and then add some 0s to the left side if you are younger than 64."
    ]

--- a/content/ch-states/states-many-qubits.ipynb
+++ b/content/ch-states/states-many-qubits.ipynb
@@ -154,7 +154,7 @@
     "\n",
     "The $zz$ in $P^{zz}_{0}$ and $P^{zz}_{1}$ refers to the fact that these probabilities describe the outcomes when a z measurement is made on both qubits.  A quantity such as $\\langle a|Z\\otimes X|a\\rangle$ will reflect similar probabilities for different choices of measurements on the qubits.\n",
     "\n",
-    "The $0$ and $1$ of $P^{zz}_{0}$ and $P^{zz}_{1}$ refer to whether there are an even (for $0$) or odd (for $1$) number of ```1``` outcomes in the output. So $P^{zz}_{0}$ is the probability that the result is either ```00``` or ```11```, and $P^{zz}_{01}$  is the probability that the result is either ```01``` or ```10```.\n",
+    "The $0$ and $1$ of $P^{zz}_{0}$ and $P^{zz}_{1}$ refer to whether there are an even (for $0$) or odd (for $1$) number of ```1``` outcomes in the output. So $P^{zz}_{0}$ is the probability that the result is either ```00``` or ```11```, and $P^{zz}_{1}$  is the probability that the result is either ```01``` or ```10```.\n",
     "\n",
     "These multiqubit Pauli operators can be used to analyze a new kind of state, that cannot be described as a simple tensor product of two independent qubit states. For example,\n",
     "\n",


### PR DESCRIPTION
Fixed what appear to be two small typos in the textbook. First, in ch-states/atoms-computation, changed a phrase that said qubits were numbered left-to-right, to say instead that qubits are numbered right-to-left.

Secondly, in ch-states/states-many-qubits, there was a term $P^{zz}_{01}$ where the subscript "01" seems incorrect and it should read "1" instead.