### PR TITLE
Toffoli Controls need to be in state |1>

### DIFF
--- a/content/ch-gates/basic-circuit-identities.ipynb
+++ b/content/ch-gates/basic-circuit-identities.ipynb
@@ -351,7 +351,7 @@
     "\n",
     "![A controlled version of a gate V](https://s3.us-south.cloud-object-storage.appdomain.cloud/strapi/4efe86a907a64a59a720b4dc54a98a88iden1.png)\n",
     "\n",
-    "Here `A`, `B` and `C` are gates that implement $A$ , $B$ and $C$, and must be defined as custom gates. For example, if we wanted $A$ to be $R_x(\\pi/4)$, the custom would be defined as\n",
+    "Here `A`, `B` and `C` are gates that implement $A$ , $B$ and $C$, respectively, and must be defined as custom gates. For example, if we wanted $A$ to be $R_x(\\pi/4)$, the custom would be defined as\n",
     "\n",
     "```python\n",
     "qc_a = QuantumCircuit(1, name='A')\n",

--- a/content/ch-gates/basic-circuit-identities.ipynb
+++ b/content/ch-gates/basic-circuit-identities.ipynb
@@ -371,7 +371,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Toffoli gate is a three-qubit gate with two controls and one target. It performs an X on the target only if both controls are in the state $|0\\rangle$. The final state of the target is then equal to either the AND or the NAND of the two controls, depending on whether the initial state of the target was $|0\\rangle$ or $|1\\rangle$. A Toffoli can also be thought of as a controlled-controlled-NOT, and is also called the CCX gate.\n",
+    "The Toffoli gate is a three-qubit gate with two controls and one target. It performs an X on the target only if both controls are in the state $|1\\rangle$. The final state of the target is then equal to either the AND or the NAND of the two controls, depending on whether the initial state of the target was $|0\\rangle$ or $|1\\rangle$. A Toffoli can also be thought of as a controlled-controlled-NOT, and is also called the CCX gate.\n",
     "\n",
     "```python\n",
     "# Toffoli with control qubits a and b and target t\n",


### PR DESCRIPTION
Fixes #134 

From: 
`It performs an X on the target only if both controls are in the state |0>.`

To:
`It performs an X on the target only if both controls are in the state |1>.`