### PR TITLE
Use 2.1.2 as fixed bundler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
   - gem update --system
-  - gem install bundler
+  - gem install bundler -v 2.1.2
   - make install
 script:
   - make book

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 install:
 	# Check to see whether bundler is already installed. If not, install it.
 	if [ hash bundler 2>/dev/null ]; then \
-	gem install bundler;\
+		gem install bundler -v 2.1.2;\
 	fi
 	bundle install
 


### PR DESCRIPTION
Fixes #140 

The other possible solution would be to remove the "BUNDLED WITH" constraint from the Gemfile.lock - but this could break future builds. 
With this solution we just have to periodically test and update the bundler version (*if* we want to use a newer bundler version).