### PR TITLE
Fixed two typos in linear_algebra.ipynb

### DIFF
--- a/content/ch-prerequisites/linear_algebra.ipynb
+++ b/content/ch-prerequisites/linear_algebra.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "We will start our investigation into introductory linear algebra by first discussing one of the most important mathematical quantities in quantum computation, the vector!\n",
     "\n",
-    "Formally, a **vector** $|v\\rangle$ is defined as elements of a set known as a vector space. A more intutive and geometric definition as that a vector \"is a mathematical quantity with both direction and magnitude\". For instance, consider a vector with $x$ and $y$ components of the form $\\begin{pmatrix} 3 \\\\ 5 \\end{pmatrix}$. This vector can be visualized as an arrow pointing in the direction of $3$ unit down the $x$ axis and $5$ units up the $y$ axis:"
+    "Formally, a **vector** $|v\\rangle$ is defined as elements of a set known as a vector space. A more intutive and geometric definition is that a vector \"is a mathematical quantity with both direction and magnitude\". For instance, consider a vector with $x$ and $y$ components of the form $\\begin{pmatrix} 3 \\\\ 5 \\end{pmatrix}$. This vector can be visualized as an arrow pointing in the direction of $3$ unit down the $x$ axis and $5$ units up the $y$ axis:"
    ]
   },
   {

--- a/content/ch-prerequisites/linear_algebra.ipynb
+++ b/content/ch-prerequisites/linear_algebra.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "We will start our investigation into introductory linear algebra by first discussing one of the most important mathematical quantities in quantum computation, the vector!\n",
     "\n",
-    "Formally, a **vector** $|v\\rangle$ is defined as elements of a set known as a vector space. A more intutive and geometric definition is that a vector \"is a mathematical quantity with both direction and magnitude\". For instance, consider a vector with $x$ and $y$ components of the form $\\begin{pmatrix} 3 \\\\ 5 \\end{pmatrix}$. This vector can be visualized as an arrow pointing in the direction of $3$ unit down the $x$ axis and $5$ units up the $y$ axis:"
+    "Formally, a **vector** $|v\\rangle$ is defined as elements of a set known as a vector space. A more intuitive and geometric definition is that a vector \"is a mathematical quantity with both direction and magnitude\". For instance, consider a vector with $x$ and $y$ components of the form $\\begin{pmatrix} 3 \\\\ 5 \\end{pmatrix}$. This vector can be visualized as an arrow pointing in the direction of $3$ unit down the $x$ axis and $5$ units up the $y$ axis:"
    ]
   },
   {


### PR DESCRIPTION
The sentence "A more intutive and geometric definition as that a vector..." has two typos.

1. "intutive" is misspelled and should be "intuitive"'

2. "as that a vector" should be "is that a vector"