### PR TITLE
Refactoring VQE Molecules Notebook to work with current Qiskit Version

### DIFF
--- a/content/ch-applications/vqe-molecules.ipynb
+++ b/content/ch-applications/vqe-molecules.ipynb
@@ -242,9 +242,9 @@
      "output_type": "stream",
      "text": [
       "Target Distribution: [0.51357006 0.48642994]\n",
-      "Obtained Distribution: [0.5182, 0.4818]\n",
-      "Output Error (Manhattan Distance): 0.0001401187388391789\n",
-      "Parameters Found: [1.59966854 0.66273002 0.28432001]\n"
+      "Obtained Distribution: [0.5206, 0.4794]\n",
+      "Output Error (Manhattan Distance): 0.008659881261160907\n",
+      "Parameters Found: [1.54305723 0.1226433  0.48569819]\n"
      ]
     }
    ],
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -291,53 +291,53 @@
      "output_type": "stream",
      "text": [
       "=============Linear Entanglement:=============\n",
-      "        ┌───────────┐┌───────┐                      ┌───────────┐  ┌───────┐                »\n",
-      "q_0: |0>┤ U3(0,0,0) ├┤ U1(0) ├──────────────────■───┤ U3(0,0,0) ├──┤ U1(0) ├────────────────»\n",
-      "        ├───────────┤├───────┤┌──────────────┐┌─┴─┐┌┴───────────┴─┐└───────┘ ┌───────────┐  »\n",
-      "q_1: |0>┤ U3(0,0,0) ├┤ U1(0) ├┤ U2(0,3.1416) ├┤ X ├┤ U2(0,3.1416) ├────■─────┤ U3(0,0,0) ├──»\n",
-      "        ├───────────┤├───────┤├──────────────┤└───┘└──────────────┘  ┌─┴─┐  ┌┴───────────┴─┐»\n",
-      "q_2: |0>┤ U3(0,0,0) ├┤ U1(0) ├┤ U2(0,3.1416) ├───────────────────────┤ X ├──┤ U2(0,3.1416) ├»\n",
-      "        ├───────────┤├───────┤├──────────────┤                       └───┘  └──────────────┘»\n",
-      "q_3: |0>┤ U3(0,0,0) ├┤ U1(0) ├┤ U2(0,3.1416) ├──────────────────────────────────────────────»\n",
-      "        └───────────┘└───────┘└──────────────┘                                              »\n",
-      "«                                                     ░ \n",
-      "«q_0: ────────────────────────────────────────────────░─\n",
-      "«     ┌───────┐                                       ░ \n",
-      "«q_1: ┤ U1(0) ├───────────────────────────────────────░─\n",
-      "«     └───────┘ ┌───────────┐    ┌───────┐            ░ \n",
-      "«q_2: ────■─────┤ U3(0,0,0) ├────┤ U1(0) ├────────────░─\n",
-      "«       ┌─┴─┐  ┌┴───────────┴─┐┌─┴───────┴─┐┌───────┐ ░ \n",
-      "«q_3: ──┤ X ├──┤ U2(0,3.1416) ├┤ U3(0,0,0) ├┤ U1(0) ├─░─\n",
-      "«       └───┘  └──────────────┘└───────────┘└───────┘ ░ \n",
+      "        ┌───────────┐┌───────┐ ░                                                                 ░ »\n",
+      "q_0: |0>┤ U3(0,0,0) ├┤ U1(0) ├─░───────────────■─────────────────────────────────────────────────░─»\n",
+      "        ├───────────┤├───────┤ ░ ┌──────────┐┌─┴─┐┌──────────┐                                   ░ »\n",
+      "q_1: |0>┤ U3(0,0,0) ├┤ U1(0) ├─░─┤ U2(0,pi) ├┤ X ├┤ U2(0,pi) ├──■────────────────────────────────░─»\n",
+      "        ├───────────┤├───────┤ ░ ├──────────┤└───┘└──────────┘┌─┴─┐┌──────────┐                  ░ »\n",
+      "q_2: |0>┤ U3(0,0,0) ├┤ U1(0) ├─░─┤ U2(0,pi) ├─────────────────┤ X ├┤ U2(0,pi) ├──■───────────────░─»\n",
+      "        ├───────────┤├───────┤ ░ ├──────────┤                 └───┘└──────────┘┌─┴─┐┌──────────┐ ░ »\n",
+      "q_3: |0>┤ U3(0,0,0) ├┤ U1(0) ├─░─┤ U2(0,pi) ├──────────────────────────────────┤ X ├┤ U2(0,pi) ├─░─»\n",
+      "        └───────────┘└───────┘ ░ └──────────┘                                  └───┘└──────────┘ ░ »\n",
+      "«     ┌───────────┐┌───────┐ ░ \n",
+      "«q_0: ┤ U3(0,0,0) ├┤ U1(0) ├─░─\n",
+      "«     ├───────────┤├───────┤ ░ \n",
+      "«q_1: ┤ U3(0,0,0) ├┤ U1(0) ├─░─\n",
+      "«     ├───────────┤├───────┤ ░ \n",
+      "«q_2: ┤ U3(0,0,0) ├┤ U1(0) ├─░─\n",
+      "«     ├───────────┤├───────┤ ░ \n",
+      "«q_3: ┤ U3(0,0,0) ├┤ U1(0) ├─░─\n",
+      "«     └───────────┘└───────┘ ░ \n",
       "\n",
       "=============Full Entanglement:=============\n",
-      "        ┌───────────┐┌───────┐                                                               »\n",
-      "q_0: |0>┤ U3(0,0,0) ├┤ U1(0) ├──────────────────■────■────────────────────■──────────────────»\n",
-      "        ├───────────┤├───────┤┌──────────────┐┌─┴─┐  │  ┌──────────────┐  │                  »\n",
-      "q_1: |0>┤ U3(0,0,0) ├┤ U1(0) ├┤ U2(0,3.1416) ├┤ X ├──┼──┤ U2(0,3.1416) ├──┼──────────────────»\n",
-      "        ├───────────┤├───────┤├──────────────┤└───┘┌─┴─┐└──────────────┘  │  ┌──────────────┐»\n",
-      "q_2: |0>┤ U3(0,0,0) ├┤ U1(0) ├┤ U2(0,3.1416) ├─────┤ X ├──────────────────┼──┤ U2(0,3.1416) ├»\n",
-      "        ├───────────┤├───────┤├──────────────┤     └───┘                ┌─┴─┐└──────────────┘»\n",
-      "q_3: |0>┤ U3(0,0,0) ├┤ U1(0) ├┤ U2(0,3.1416) ├──────────────────────────┤ X ├────────────────»\n",
-      "        └───────────┘└───────┘└──────────────┘                          └───┘                »\n",
-      "«      ┌───────────┐     ┌───────┐                                                              »\n",
-      "«q_0: ─┤ U3(0,0,0) ├─────┤ U1(0) ├──────────────────────────────────────────────────────────────»\n",
-      "«      └───────────┘     └───────┘                          ┌───────────┐     ┌───────┐         »\n",
-      "«q_1: ───────────────────────■──────────■───────────────────┤ U3(0,0,0) ├─────┤ U1(0) ├─────────»\n",
-      "«     ┌──────────────┐     ┌─┴─┐        │  ┌──────────────┐ └───────────┘     └───────┘         »\n",
-      "«q_2: ┤ U2(0,3.1416) ├─────┤ X ├────────┼──┤ U2(0,3.1416) ├──────────────────────────────────■──»\n",
-      "«     ├──────────────┤┌────┴───┴─────┐┌─┴─┐└──────────────┘┌──────────────┐┌──────────────┐┌─┴─┐»\n",
-      "«q_3: ┤ U2(0,3.1416) ├┤ U2(0,3.1416) ├┤ X ├────────────────┤ U2(0,3.1416) ├┤ U2(0,3.1416) ├┤ X ├»\n",
-      "«     └──────────────┘└──────────────┘└───┘                └──────────────┘└──────────────┘└───┘»\n",
-      "«                                            ░ \n",
-      "«q_0: ───────────────────────────────────────░─\n",
-      "«                                            ░ \n",
-      "«q_1: ───────────────────────────────────────░─\n",
-      "«      ┌───────────┐    ┌───────┐            ░ \n",
-      "«q_2: ─┤ U3(0,0,0) ├────┤ U1(0) ├────────────░─\n",
-      "«     ┌┴───────────┴─┐┌─┴───────┴─┐┌───────┐ ░ \n",
-      "«q_3: ┤ U2(0,3.1416) ├┤ U3(0,0,0) ├┤ U1(0) ├─░─\n",
-      "«     └──────────────┘└───────────┘└───────┘ ░ \n",
+      "        ┌───────────┐┌───────┐ ░                                                                »\n",
+      "q_0: |0>┤ U3(0,0,0) ├┤ U1(0) ├─░───────────────■────────────────■────────────────■──────────────»\n",
+      "        ├───────────┤├───────┤ ░ ┌──────────┐┌─┴─┐┌──────────┐  │                │              »\n",
+      "q_1: |0>┤ U3(0,0,0) ├┤ U1(0) ├─░─┤ U2(0,pi) ├┤ X ├┤ U2(0,pi) ├──┼────────────────┼──────────────»\n",
+      "        ├───────────┤├───────┤ ░ ├──────────┤└───┘└──────────┘┌─┴─┐┌──────────┐  │  ┌──────────┐»\n",
+      "q_2: |0>┤ U3(0,0,0) ├┤ U1(0) ├─░─┤ U2(0,pi) ├─────────────────┤ X ├┤ U2(0,pi) ├──┼──┤ U2(0,pi) ├»\n",
+      "        ├───────────┤├───────┤ ░ ├──────────┤                 └───┘└──────────┘┌─┴─┐├──────────┤»\n",
+      "q_3: |0>┤ U3(0,0,0) ├┤ U1(0) ├─░─┤ U2(0,pi) ├──────────────────────────────────┤ X ├┤ U2(0,pi) ├»\n",
+      "        └───────────┘└───────┘ ░ └──────────┘                                  └───┘└──────────┘»\n",
+      "«                                                                            ░ ┌───────────┐»\n",
+      "«q_0: ───────────────────────────────────────────────────────────────────────░─┤ U3(0,0,0) ├»\n",
+      "«                                                                            ░ ├───────────┤»\n",
+      "«q_1: ─────■────────────────────■────────────────────────────────────────────░─┤ U3(0,0,0) ├»\n",
+      "«        ┌─┴─┐    ┌──────────┐  │                                            ░ ├───────────┤»\n",
+      "«q_2: ───┤ X ├────┤ U2(0,pi) ├──┼────────────────────────────■───────────────░─┤ U3(0,0,0) ├»\n",
+      "«     ┌──┴───┴───┐└──────────┘┌─┴─┐┌──────────┐┌──────────┐┌─┴─┐┌──────────┐ ░ ├───────────┤»\n",
+      "«q_3: ┤ U2(0,pi) ├────────────┤ X ├┤ U2(0,pi) ├┤ U2(0,pi) ├┤ X ├┤ U2(0,pi) ├─░─┤ U3(0,0,0) ├»\n",
+      "«     └──────────┘            └───┘└──────────┘└──────────┘└───┘└──────────┘ ░ └───────────┘»\n",
+      "«     ┌───────┐ ░ \n",
+      "«q_0: ┤ U1(0) ├─░─\n",
+      "«     ├───────┤ ░ \n",
+      "«q_1: ┤ U1(0) ├─░─\n",
+      "«     ├───────┤ ░ \n",
+      "«q_2: ┤ U1(0) ├─░─\n",
+      "«     ├───────┤ ░ \n",
+      "«q_3: ┤ U1(0) ├─░─\n",
+      "«     └───────┘ ░ \n",
       "\n"
      ]
     }
@@ -352,7 +352,7 @@
     "    else:\n",
     "        print(\"=============Full Entanglement:=============\")\n",
     "    # We initialize all parameters to 0 for this demonstration\n",
-    "    print(form.construct_circuit([0] * form.num_parameters).draw(line_length=100))\n",
+    "    print(form.construct_circuit([0] * form.num_parameters).draw(fold=100))\n",
     "    print()"
    ]
   },
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,10 +383,11 @@
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
     "import numpy as np\n",
-    "from qiskit.chemistry.aqua_extensions.components.variational_forms import UCCSD\n",
+    "from qiskit.chemistry.components.variational_forms import UCCSD\n",
+    "from qiskit.chemistry.components.initial_states import HartreeFock\n",
     "from qiskit.aqua.components.variational_forms import RYRZ\n",
-    "from qiskit.chemistry.aqua_extensions.components.initial_states import HartreeFock\n",
     "from qiskit.aqua.components.optimizers import COBYLA, SPSA, SLSQP\n",
+    "from qiskit.aqua.operators import Z2Symmetries\n",
     "from qiskit import IBMQ, BasicAer, Aer\n",
     "from qiskit.chemistry.drivers import PySCFDriver, UnitsType\n",
     "from qiskit.chemistry import FermionicOperator\n",
@@ -406,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -431,7 +432,7 @@
     "    ferOp = ferOp.fermion_mode_elimination(remove_list)\n",
     "    num_spin_orbitals -= len(remove_list)\n",
     "    qubitOp = ferOp.mapping(map_type='parity', threshold=0.00000001)\n",
-    "    qubitOp = qubitOp.two_qubit_reduced_operator(num_particles)\n",
+    "    qubitOp = Z2Symmetries.two_qubit_reduction(qubitOp, num_particles)\n",
     "    shift = energy_shift + repulsion_energy\n",
     "    return qubitOp, num_particles, num_spin_orbitals, shift"
    ]
@@ -449,48 +450,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Interatomic Distance: 0.5 VQE Result: -7.039710219020506 Exact Energy: -7.039732521635202\n",
-      "Interatomic Distance: 0.6 VQE Result: -7.313344302334236 Exact Energy: -7.313345828761008\n",
-      "Interatomic Distance: 0.7 VQE Result: -7.500921095743192 Exact Energy: -7.500922090905936\n",
-      "Interatomic Distance: 0.8 VQE Result: -7.630976914468914 Exact Energy: -7.630978249333209\n",
-      "Interatomic Distance: 0.9 VQE Result: -7.7208107952020795 Exact Energy: -7.720812412134773\n",
-      "Interatomic Distance: 1.0 VQE Result: -7.782240655298441 Exact Energy: -7.782242402637011\n",
-      "Interatomic Distance: 1.1 VQE Result: -7.823597493320795 Exact Energy: -7.82359927636281\n",
-      "Interatomic Distance: 1.2 VQE Result: -7.850696622934822 Exact Energy: -7.850698377596024\n",
-      "Interatomic Distance: 1.3 VQE Result: -7.867561602181376 Exact Energy: -7.867563290110052\n",
-      "Interatomic Distance: 1.4 VQE Result: -7.876999876757721 Exact Energy: -7.877001491818373\n",
-      "Interatomic Distance: 1.5 VQE Result: -7.8810141736656405 Exact Energy: -7.881015715646992\n",
-      "Interatomic Distance: 1.6 VQE Result: -7.881070662952161 Exact Energy: -7.88107204403092\n",
-      "Interatomic Distance: 1.7 VQE Result: -7.878267162143656 Exact Energy: -7.878268167584993\n",
-      "Interatomic Distance: 1.8 VQE Result: -7.873440112155302 Exact Energy: -7.873440293132828\n",
-      "Interatomic Distance: 1.9 VQE Result: -7.86723366674701 Exact Energy: -7.8672339648160285\n",
-      "Interatomic Distance: 2.0 VQE Result: -7.860152327529411 Exact Energy: -7.86015320737878\n",
-      "Interatomic Distance: 2.1 VQE Result: -7.852595105536979 Exact Energy: -7.852595827876738\n",
-      "Interatomic Distance: 2.2 VQE Result: -7.844878726366329 Exact Energy: -7.844879093009722\n",
-      "Interatomic Distance: 2.3 VQE Result: -7.837257439448259 Exact Energy: -7.8372579676155025\n",
-      "Interatomic Distance: 2.4 VQE Result: -7.829935045088515 Exact Energy: -7.829937002623394\n",
-      "Interatomic Distance: 2.5 VQE Result: -7.823070191557451 Exact Energy: -7.82307664213409\n",
-      "Interatomic Distance: 2.6 VQE Result: -7.816782591999657 Exact Energy: -7.816795150472929\n",
-      "Interatomic Distance: 2.7 VQE Result: -7.8111534373726 Exact Energy: -7.811168284803366\n",
-      "Interatomic Distance: 2.8 VQE Result: -7.806218299266321 Exact Energy: -7.806229560089845\n",
-      "Interatomic Distance: 2.9 VQE Result: -7.801962397475152 Exact Energy: -7.8019736023325486\n",
-      "Interatomic Distance: 3.0 VQE Result: -7.798352412318197 Exact Energy: -7.7983634309151295\n",
-      "Interatomic Distance: 3.1 VQE Result: -7.795326815750017 Exact Energy: -7.795340451637537\n",
-      "Interatomic Distance: 3.2 VQE Result: -7.792800698225245 Exact Energy: -7.792834806738612\n",
-      "Interatomic Distance: 3.3 VQE Result: -7.790603799019874 Exact Energy: -7.790774009971014\n",
-      "Interatomic Distance: 3.4 VQE Result: -7.788715354695274 Exact Energy: -7.789088897991478\n",
-      "Interatomic Distance: 3.5 VQE Result: -7.787215781080283 Exact Energy: -7.787716973466144\n",
-      "Interatomic Distance: 3.6 VQE Result: -7.786080393658009 Exact Energy: -7.786603763673838\n",
-      "Interatomic Distance: 3.7 VQE Result: -7.785203497342158 Exact Energy: -7.785702912499886\n",
-      "Interatomic Distance: 3.8 VQE Result: -7.7844795319924325 Exact Energy: -7.784975591698873\n",
-      "Interatomic Distance: 3.9 VQE Result: -7.783853361693722 Exact Energy: -7.7843896116723315\n",
+      "Interatomic Distance: 0.5 VQE Result: -7.039710215565218 Exact Energy: -7.0397325216352\n",
+      "Interatomic Distance: 0.6 VQE Result: -7.31334430290689 Exact Energy: -7.313345828761003\n",
+      "Interatomic Distance: 0.7 VQE Result: -7.500921095751998 Exact Energy: -7.500922090905937\n",
+      "Interatomic Distance: 0.8 VQE Result: -7.630976914888905 Exact Energy: -7.630978249333209\n",
+      "Interatomic Distance: 0.9 VQE Result: -7.7208107948706335 Exact Energy: -7.720812412134779\n",
+      "Interatomic Distance: 1.0 VQE Result: -7.782240655507769 Exact Energy: -7.782242402637009\n",
+      "Interatomic Distance: 1.1 VQE Result: -7.823597493067004 Exact Energy: -7.823599276362815\n",
+      "Interatomic Distance: 1.2 VQE Result: -7.850696622555617 Exact Energy: -7.8506983775960215\n",
+      "Interatomic Distance: 1.3 VQE Result: -7.867561602360669 Exact Energy: -7.867563290110055\n",
+      "Interatomic Distance: 1.4 VQE Result: -7.876999876625421 Exact Energy: -7.877001491818371\n",
+      "Interatomic Distance: 1.5 VQE Result: -7.881014173736876 Exact Energy: -7.881015715646997\n",
+      "Interatomic Distance: 1.6 VQE Result: -7.881070663268204 Exact Energy: -7.8810720440309145\n",
+      "Interatomic Distance: 1.7 VQE Result: -7.878267161938819 Exact Energy: -7.878268167584997\n",
+      "Interatomic Distance: 1.8 VQE Result: -7.873440112088826 Exact Energy: -7.873440293132828\n",
+      "Interatomic Distance: 1.9 VQE Result: -7.8672336666975875 Exact Energy: -7.867233964816027\n",
+      "Interatomic Distance: 2.0 VQE Result: -7.860152328052092 Exact Energy: -7.8601532073787785\n",
+      "Interatomic Distance: 2.1 VQE Result: -7.852595105573739 Exact Energy: -7.852595827876739\n",
+      "Interatomic Distance: 2.2 VQE Result: -7.844878726257743 Exact Energy: -7.844879093009718\n",
+      "Interatomic Distance: 2.3 VQE Result: -7.837257439559378 Exact Energy: -7.837257967615506\n",
+      "Interatomic Distance: 2.4 VQE Result: -7.829935044964875 Exact Energy: -7.829937002623397\n",
+      "Interatomic Distance: 2.5 VQE Result: -7.823070191793284 Exact Energy: -7.823076642134093\n",
+      "Interatomic Distance: 2.6 VQE Result: -7.8167825917026885 Exact Energy: -7.8167951504729345\n",
+      "Interatomic Distance: 2.7 VQE Result: -7.811153437700115 Exact Energy: -7.811168284803364\n",
+      "Interatomic Distance: 2.8 VQE Result: -7.806218298530634 Exact Energy: -7.8062295600898475\n",
+      "Interatomic Distance: 2.9 VQE Result: -7.801962397110541 Exact Energy: -7.80197360233255\n",
+      "Interatomic Distance: 3.0 VQE Result: -7.798352411524604 Exact Energy: -7.7983634309151295\n",
+      "Interatomic Distance: 3.1 VQE Result: -7.7953268158537385 Exact Energy: -7.795340451637538\n",
+      "Interatomic Distance: 3.2 VQE Result: -7.792800697723607 Exact Energy: -7.7928348067386075\n",
+      "Interatomic Distance: 3.3 VQE Result: -7.790603800220275 Exact Energy: -7.790774009971013\n",
+      "Interatomic Distance: 3.4 VQE Result: -7.788715355351082 Exact Energy: -7.789088897991485\n",
+      "Interatomic Distance: 3.5 VQE Result: -7.787215777163667 Exact Energy: -7.787716973466142\n",
+      "Interatomic Distance: 3.6 VQE Result: -7.786080385670116 Exact Energy: -7.786603763673839\n",
+      "Interatomic Distance: 3.7 VQE Result: -7.785203496927196 Exact Energy: -7.785702912499905\n",
+      "Interatomic Distance: 3.8 VQE Result: -7.78447953997175 Exact Energy: -7.784975591698672\n",
+      "Interatomic Distance: 3.9 VQE Result: -7.783853365855263 Exact Energy: -7.784389611675315\n",
       "All energies have been calculated\n"
      ]
     }
@@ -519,7 +520,7 @@
     "        initial_state=initial_state,\n",
     "        qubit_mapping='parity'\n",
     "    )\n",
-    "    vqe = VQE(qubitOp, var_form, optimizer, 'matrix')\n",
+    "    vqe = VQE(qubitOp, var_form, optimizer)\n",
     "    results = vqe.run(backend)['energy'] + shift\n",
     "    vqe_energies.append(results)\n",
     "    print(\"Interatomic Distance:\", np.round(dist, 2), \"VQE Result:\", results, \"Exact Energy:\", exact_energies[-1])\n",
@@ -529,14 +530,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 9,
    "metadata": {
     "scrolled": true
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEKCAYAAAAFJbKyAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xl4HOWZ7v/vo27tm7XZsi3Jso13jFcMxHGCDQZC2BeDQzJjCOEXCBDInJMTJpMw5BdmMpMwAxMmyWFJyIQEDDgJJGH1AEMIYLxgvG94lRdZlrXa2lr9nj+6pchyy27JalXLuj/X1Re1ddXd1aYf1VtVb5lzDhERkWgleB1ARET6FxUOERHpFhUOERHpFhUOERHpFhUOERHpFhUOERHpFk8Kh5ktNrPV4ddOM1vdxXKXmNlmM9tmZt/q65wiInI88/o+DjN7CKhxzn2v03QfsAWYD5QBy4GFzrkNfZ9SRETaeNpUZWYGLACeiTB7FrDNObfdOdcMPAtc2Zf5RETkeH6Ptz8HKHfObY0wbziwp8N4GXBONCvNz893paWlp55ORGSAWLly5SHnXEE0y8ascJjZUqAwwqxvO+deDA8vJPLRRk+2dxtwG0BJSQkrVqzojdWKiAwIZrYr2mVjVjiccxeeaL6Z+YFrgBldLLIXKO4wXhSe1tX2HgMeA5g5c6Y64BIRiREvz3FcCGxyzpV1MX85MMbMRppZEnAj8FKfpRMRkYi8LBw30qmZysyGmdnLAM65AHAn8BqwEXjOObe+z1OKiMgxPDs57pxbFGHaPuDSDuMvAy/3YSwR6WUtLS2UlZXR2NjodRQBUlJSKCoqIjExscfr8PqqKhE5zZWVlZGZmUlpaSmhK/DFK845KisrKSsrY+TIkT1ej7ocEZGYamxsJC8vT0UjDpgZeXl5p3z0p8IhIjGnohE/euO7UOEIaw0E+OCXf8/a//mt11FEROKaCkdYgs/HxB1PcXTNiydfWET6DZ/Px9SpU9tfP/jBD3pt3atXr+bllyNfv/P222+TnZ19zLaXLl3aa9v2kk6Oh5kZ5f5hpNXv9jqKiPSi1NRUVq+O2AH3KVu9ejUrVqzg0ksvjTh/zpw5/PGPf+zVbQYCAfx+b3+6dcTRQU1qMbnNXd6cLiKniZqaGsaNG8fmzZsBWLhwIY8//jgAt99+OzNnzmTSpEncf//97e9Zvnw5n/rUp5gyZQqzZs2ipqaG7373uyxevJipU6eyePHiqLa9c+dOJkyYwFe+8hUmTZrERRddRENDAwCffPIJl1xyCTNmzGDOnDls2rQJgEWLFvHVr36Vc845h29+85tUVFQwf/58Jk2axK233sqIESM4dOgQ3/3ud3n44Yfbt/Xtb3+bRx55pFf2WUc64uigJWsEhbVv0dLcSGJSitdxRE47D/xhPRv21fbqOicOy+L+yyd1Ob+hoYGpU6e2j993333ccMMNPProoyxatIivf/3rVFVV8ZWvfAWABx98kNzcXFpbW7ngggtYs2YN48eP54YbbmDx4sWcffbZ1NbWkpaWxve+9z1WrFjBo48+GnHbf/7zn4/Z9pIlS/D5fGzdupVnnnmGxx9/nAULFrBkyRK++MUvctttt/Gzn/2MMWPGsGzZMu644w7efPNNIHRZ83vvvYfP5+POO+9k3rx53Hfffbz66qs8+eSTANxyyy1cc8013HPPPQSDQZ599lk+/PDDU97HnalwdODLH41vr2P/7q0UnTHZ6zgi0gu6aqqaP38+zz//PF/72tf4+OOP26c/99xzPPbYYwQCAfbv38+GDRswM4YOHcrZZ58NQFZWVlTbjtRUtXPnTkaOHNleUGbMmMHOnTupr6/nvffe4/rrr29ftqmpqX34+uuvx+fzAfDuu+/yu9/9DoBLLrmEnJwcAEpLS8nLy+Ojjz6ivLycadOmkZeXF1XW7lDh6CBj6Bj4GA7v2azCIRIDJzoy6GvBYJCNGzeSlpZGVVUVRUVF7Nixgx/96EcsX76cnJwcFi1aFJM73pOTk9uHfT4fDQ0NBINBBg0a1OX5mPT09KjWfeutt/LUU09x4MABbrnlll7J25nOcXQwuGQCAA3lkR4PIiKnk3//939nwoQJ/OY3v+Hmm2+mpaWF2tpa0tPTyc7Opry8nFdeeQWAcePGsX//fpYvXw5AXV0dgUCAzMxM6urqeiVPVlYWI0eO5PnnnwdCd3l3PBLqaPbs2Tz33HMAvP7661RVVbXPu/rqq3n11VdZvnw5F198ca9k60yFo4O8wmKOumTc4R1eRxGRXtJ2jqPt9a1vfYvNmzfzxBNP8NBDDzFnzhw+85nP8P3vf58pU6Ywbdo0xo8fzxe+8AVmz54NQFJSEosXL+auu+5iypQpzJ8/n8bGRubOncuGDRu6PDnedo6j7fXCCy+cMOuvf/1rnnzySaZMmcKkSZN48cXItwfcf//9vP7665x55pk8//zzFBYWkpmZ2Z517ty5LFiwoL1pq7d5/szxWJg5c6br6YOcdnxvCjXJhUz9P6/1ciqRgWnjxo1MmDDB6xinlaamJnw+H36/n/fff5/bb7+9vYkrGAwyffp0nn/+ecaMGRPx/ZG+EzNb6ZybGc32dY6jk+rUInIbdnodQ0SkS7t372bBggUEg0GSkpLaLyXesGEDl112GVdffXWXRaM3qHB00pQ5gqH1H9AaCODz+CYbEZFIxowZw0cffXTc9IkTJ7J9+/aYb1/nODqxvFEkWYCKfTrPISISiQpHJ+mFocO7Q7s3epxERCQ+qXB0klcyHoCjB7Z5nEREJD6pcHQyePhomp2P1spPvI4iIhKXVDg68fn9HPAVklK7y+soInKK5s6dy2uvHXtp/cMPP8ztt98OwPr165k3bx7jxo1j9OjR3H///QSDQQCeeuopCgoKjrkPY8OGDcdtI5bdtscrXTYUweHkIrIay7yOISKnaOHChTz77LPH3EH97LPP8q//+q80NDRwxRVX8NOf/pSLLrqIo0ePcu211/LII49w7733ArR3hngisei2PR66Tj8RHXFE0JhRwtDAPlz4Lw8R6Z+uu+46/vSnP9Hc3AyEOhjct28fc+bM4Te/+Q2zZ8/moosuAiAtLY1HH32UH/7wh72y7dLSUu6//36mT5/O5MmT27tIP3LkCLfccguzZs1i2rRp7XeHP/XUU1xxxRXMmzePCy64gGAwyB133MH48eOZP38+l156KS+88AJvvvkmV111Vft23njjDa6++upeyRyt+C1pXsodRVpFE4cO7iW/sNjrNCKnj1e+BQfW9u46CyfD5yI3D+Xm5jJr1ixeeeUVrrzySp599lkWLFiAmbF+/XpmzJhxzPKjR4+moaGB6upqABYvXsy7777bPv/9998nNTX1mPd01W07QH5+PqtWreInP/kJP/rRj3jiiSd48MEHmTdvHj//+c+prq5m1qxZXHjhhQCsWrWKNWvWkJubywsvvMDOnTvZsGEDBw8eZMKECdxyyy3MnTuXO+64g4qKCgoKCvjFL34Rs84Mu6IjjghSh4Qvyd2lS3JF+ru25ioINVMtXLgw6vfecMMNrF69uv3VuWjAX5uq2l5tRQPgmmuuAf7adTqEOiX8wQ9+wNSpUzn//PNpbGxk9+7Qk0fnz59Pbm4uEOo6/frrrychIYHCwkLmzp0LhJ5W+qUvfYmnn36a6upq3n//fT73uc91f8ecAh1xRJBbPBaAuv1bgIu8DSNyOuniyCCWrrzySu69915WrVrF0aNH248yJk6cyDvvvHPMstu3bycvL49Bgwb1yrbbuk/3+XwEAgEg1OvtkiVLGDdu3DHLLlu2LOqu02+++WYuv/xyUlJSuP766/v8fIiOOCIYUjKOVme0Hor9rfsiElsZGRnMnTuXW2655ZijjZtuuol3332XpUuXAqEmp7vvvpsHHnggpnkuvvhifvzjH9PWwWykrkMg1HX6kiVLCAaDlJeX8/bbb7fPGzZsGMOGDeP73/8+N998c0zzRqLCEUFScgrlCQX4a3Z6HUVEesHChQv5+OOPjykcqampvPTSSzz44IOMHTuW/Px8Zs+ezU033dS+TNvzxNte77333nHrjtRt+4l85zvfoaWlhbPOOotJkybxne98J+Jy1157LUVFRUycOJEvfvGLTJ8+nezs7Pb5N910E8XFxZ70PKxu1buw9p/PJ7n1CGP/YXkvpRIZmPpLt+q///3v+cY3vsFbb73FiBEjvI4DQH19PRkZGVRWVjJr1iz+8pe/UFhYCMCdd97JtGnT+PKXv9zt9apb9Rg5mjGC4sqlXscQkT5y1VVXHXOZazy47LLLqK6uprm5me985zvtRWPGjBmkp6fz0EMPeZJLhaMLLqeUQZX11FSWk503xOs4IjIAdTyv0dHKlSv7NkgnOsfRheTBoUtyy3dt8jiJSP93OjaJ91e98V2ocHRhUFHoUrna/Vs8TiLSv6WkpFBZWaniEQecc1RWVpKSknJK61FTVRcKR4S6V285qO7VRU5FUVERZWVlVFRUeB1FCBXyoqKiU1qHCkcXUtMzOUiuLskVOUWJiYmMHDnS6xjSi9RUdQKHkoaTcWSP1zFEROKKCscJ1KcVU9Cy1+sYIiJxRYXjBIKDRpJPNUfra7yOIiISN1Q4TsBfMBqAAzt1Sa6ISBtPCoeZLTaz1eHXTjM77vFZZlZsZm+Z2QYzW29mX+/rnNnDQ73k1uxV4RARaePJVVXOufYO683sISBSW1AA+Dvn3CozywRWmtkbzrnjH/obI4NHhPpyaTr4SV9tUkQk7nl6Oa6ZGbAAmNd5nnNuP7A/PFxnZhuB4UCfFY7snHyqyMSqdvTVJkVE4p7X5zjmAOXOua0nWsjMSoFpwLI+yHSMg/5hpB/Z3debFRGJWzE74jCzpUBhhFnfds69GB5eCDxzkvVkAEuAe5xztSdY7jbgNoCSkpIeZY6kLq2Y4bUf99r6RET6u5gVDufchSeab2Z+4BpgxgmWSSRUNH7tnPvtSbb3GPAYhJ7H0e3AXWjJLmVIzX/T1HiU5JS03lqtiEi/5WVT1YXAJudcWaSZ4fMfTwIbnXP/1qfJOvDnjybBHAd2qbNDERHwtnDcSKdmKjMbZmYvh0dnA18C5nW4dPfSvg6ZOSx0SW61LskVEQE8vKrKObcowrR9wKXh4XcB6+NYxykoCfWS23BAveSKiID3V1XFvdyCYdS7VF2SKyISpsJxEpaQwAH/MFLqdnkdRUQkLqhwRKE2dTi5TeolV0QEVDii0pRVypBgOYGWZq+jiIh4ToUjCr680SRZKwfLtnsdRUTEcyocUUgvHANA5Z6NHicREfGeCkcU8keELsk9qktyRURUOKJRMLSURpeIq1T36iIiKhxRSPD5OOArJFmX5IqIqHBEqyqlmEGNuiRXRESFI0pNmSUUtu4n2NrqdRQREU+pcETJckeRas0cOqCHOonIwKbCEaW08CW5h3arl1wRGdhUOKKUWzwOgCP79VwOERnYVDiiNKR4DC3OR+CQLskVkYFNhSNK/sQkyhMGk1SrS3JFZGBT4eiGw8nDyW7Y43UMERFPqXB0Q0NGCYNb9+OCQa+jiIh4RoWjG1zuKLI4SnVluddRREQ8o8LRDSmDzwCgfNcGj5OIiHhHhaMbcopCl+TW79vqcRIREe+ocHTDkBHjaHVG4KDu5RCRgUuFoxtSUtPZ4ysmtXKd11FERDyjwtFNFZkTGd6wWVdWiciApcLRTcGhU8mnmoP7dngdRUTEEyoc3ZR9xiwA9m143+MkIiLeUOHoptKJ5xBwCTTuWuF1FBERT6hwdFNKWga7/CNIr1zrdRQREU+ocPRAZdZEiht1glxEBiYVjh5wQ6eRQx37d+tGQBEZeFQ4eiB3zDkAHNj4nsdJRET6ngpHD5RMmEmz89G0e5XXUURE+pwKRw8kp6Sxyz+SzMNrvI4iItLnVDh66PCgSZQ0bdEJchEZcFQ4esiGTSOLo+zdri7WRWRgUeHooby2E+SbdQe5iAwsKhw9VDJ+Bk0ukcDulV5HERHpUyocPZSYlMzOxFFkVqmLdREZWDwpHGa22MxWh187zWz1CZb1mdlHZvbHvswYjepBkyht2kqwtdXrKCIifcaTwuGcu8E5N9U5NxVYAvz2BIt/HdjYN8m6x4ZPJ90a2bNN/VaJyMDhaVOVmRmwAHimi/lFwOeBJ/oyV7QKxp0LQIVOkIvIABJV4TCz35rZ582stwvNHKDcOddVp08PA98E4vJmieIxUzjqkgmU6Q5yERk4oi0EPwG+AGw1sx+Y2biTvcHMlprZugivKzsstpCujzYuAw4656K6bMnMbjOzFWa2oqKiIpq3nDJ/YhK7kkaTrRPkIjKA+KNZyDm3FFhqZtmEfuyXmtke4HHgaedcS4T3XHiidZqZH7gGmNHFIrOBK8zsUiAFyDKzp51zX+wi42PAYwAzZ8500Xyu3lCTM5mzyn9PoKUZf2JSX21WRMQzUTc9mVkesAi4FfgIeASYDrzRw21fCGxyzpVFmumcu885V+ScKwVuBN7sqmh4yV80nTRrYs/Wj72OIiLSJ6I9x/E74M9AGnC5c+4K59xi59xdQEYPt30jnZqpzGyYmb3cw/V5YvD4thPkH3icRESkb0TVVAX8h3PurUgznHMze7Jh59yiCNP2AZdGmP428HZPthNrRaMnU+9ScXt1glxEBoZoC0eOmV3TaVoNsNY5d7CXM/UrCT4fu5LHMKh6vddRRET6RLSF48vAeUDbUcf5wEpgpJl9zzn3qxhk6zfqciczbf9ztDQ3kZiU7HUcEZGYivbkeCIwwTl3rXPuWmAi4IBzgP8Tq3D9RWLxdJKthd2b1OGhiJz+oi0cRc658g7jB4Fi59xh4LhLcQeawgnnAVC5RSfIReT0F21T1dvhTgafD49fG56WDlTHJFk/Mqx0ArWk4/Z95HUUEZGYi7ZwfI3QzXqfDo//F7DEOeeAubEI1p9YQgK7kseSV6MT5CJy+jtp4TAzH7DUOTeXUE+2EkF93mTG7f01jQ1HSElN9zqOiEjMnPQch3OuFQiGuxuRLiSXzCDJWtm9cYXXUUREYirapqp6YK2ZvQEcaZvonLs7Jqn6oaETzoMPoGrbMpj+Wa/jiIjETLSF47ec+GFLA15h8RiqyMJ0glxETnPR9o77SzNLBUqcc5tjnKlfsoQE9qSMI792g9dRRERiKtpODi8HVgOvhsenmtlLsQzWHx3Jn0xJ624ajtR5HUVEJGaivQHwH4FZhO/ZcM6tBkbFKFO/lVIyA78F2bVhmddRRERiJtrC0eKcq+k0LS4f5+ql4ZNmA1C97UOPk4iIxE60J8fXm9kXAJ+ZjQHuBt6LXaz+qWDoCA4xCN+B1V5HERGJmWiPOO4CJgFNhB6+VAvcE6tQ/ZUlJFCWOp6COp0gF5HTV7RXVR0Fvh1+yQk0FJzFWbuWcaSumvTMQV7HERHpddFeVTXWzB4zs9fN7M22V6zD9UdppTNIMMeu9eopV0ROT9Ge43ge+BnwBNAauzj93/CJs+EdqN36Hpx7iddxRER6XbSFI+Cc+2lMk5wm8guL2ZEwgsw9b3sdRUQkJqI9Of4HM7vDzIaaWW7bK6bJ+rEDQz7L2KZ11FZXeh1FRKTXRVs4/hb434QuwV0Zfqkb2C5kT/k8idbKtvd1c72InH6iKhzOuZERXrpzvAtjZ8yjhnRaN7/mdRQRkV53wsJhZt/sMHx9p3n/FKtQ/Z0/MYltmecwqvo9gq26lkBETi8nO+K4scPwfZ3m6ZKhE3BjLiKPGrZ9/K7XUUREetXJCod1MRxpXDoYfd5VBJ1R+dEfvI4iItKrTlY4XBfDkcalg5yCoWxJHE/+/re9jiIi0qtOVjimmFmtmdUBZ4WH28Yn90G+fq2q6HzGBLZy6MBur6OIiPSaExYO55zPOZflnMt0zvnDw23jiX0Vsr8aPP0KALa//3uPk4iI9J5o7+OQHhh15rkcJBf/tje8jiIi0mtUOGLIEhLYmTubsfXLaW5q9DqOiEivUOGIscTxl5BhDWxZ/rrXUUREeoUKR4yNPe8ymp2f+rUvex1FRKRXqHDEWHrmIDalTmFYxTteRxER6RUqHH3g6IgLKAnuZe/29V5HERE5ZSocfaD4nKsA2LNMl+WKSP+nwtEHho+axO6E4aTt+m+vo4iInDIVjj6yr+AzjG/4mCN11V5HERE5JZ4UDjNbbGarw6+dZra6i+UGmdkLZrbJzDaa2Xl9nbW3ZEy+lCQLsOX9P3odRUTklHhSOJxzNzjnpjrnpgJLgN92segjwKvOufHAFGBjX2XsbWPPvoh6l0rLple9jiIickr8Xm7czAxYAMyLMC8b+AywCMA51ww092W+3pSUnMK6jLMpPfwXXDCIJaiVUET6J69/veYA5c65rRHmjQQqgF+Y2Udm9oSZpfdtvN4VOGM+gznM9nUfeB1FRKTHYlY4zGypma2L8Lqyw2ILgWe6WIUfmA781Dk3DTgCfOsE27vNzFaY2YqKiope+xy9adR5octyD656yeMkIiI9F7OmKufchSeab2Z+4BpgRheLlAFlzrll4fEXOEHhcM49BjwGMHPmzLh8yFR+YQlb/WPIKXvb6ygiIj3mZVPVhcAm51xZpJnOuQPAHjMbF550AbChr8LFyqGh5zO2ZRNVFfu9jiIi0iNeFo4b6dRMZWbDzKxjb4B3Ab82szXAVOCf+jBfTORNu5wEc3yihzuJSD/l2VVVzrlFEabtAy7tML4amNmHsWLujCmf5tBLg7CtrwO3ex1HRKTbvL6qasBJ8PnYMeg8xtQtI9DSb68uFpEBTIXDA75xF5PFEbasfNPrKCIi3abC4YExn7qSBpdE/bJfeR1FRKTbVDg8kJmdy9q8i5l8+HVqKsu9jiMi0i0qHB7Jn3cXqdbMxpf/0+soIiLdosLhkVFnnsOGpMmUbH+G1kDA6zgiIlFT4fBQ47QvM8wdZO1bz3kdRUQkaiocHpp84U2Uk4dvxeNeRxERiZoKh4cSE5PYXrqAyU2r2LU54rOsRETijgqHx8Z+7k6anZ8DbzzidRQRkaiocHgsb0gRHw+ax5kVL1NXc9jrOCIiJ6XCEQeyP3sn6dbI+pd/5nUUEZGTUuGIA2Onf5Yt/rEM3/Irgq2tXscRETkhFY44UXvWLRS7fax/90Wvo4iInJAKR5yYfNHfUkk2rR/8X6+jiIickApHnEhOSWNL0bWcdXQZe7dv9DqOiEiXVDjiyOjP3U0QY89rujRXROKXCkccGTx8JGsy5zCx/CUajtR5HUdEJCIVjjiT8uk7yOIIa19RNyQiEp9UOOLMhFkX8UnCSAo2/BIXDHodR0TkOCocccYSEqic9LeMDO5k47LXvI4jInIcFY44NPmSW6khnca//MTrKCIix1HhiEOp6ZlsLLyKs+re5cCebV7HERE5hgpHnCq55OuhS3Nf+Huvo4iIHEOFI04NKx3HyqIvcXbNa6z7yx+8jiMi0k6FI45Nu+lB9toQspd+k6bGo17HEREBVDjiWkpaBpWf/WeK3T5W/eYfvY4jIgKocMS9s86/lpWZc5m+6+fs2bbW6zgiIioc/cGIhY/QjJ/q5+/STYEi4jkVjn4gf9gINky8h8lNH7HyT+qKRES8pcLRT8y89n+xxT+WkSsfpOZwhddxRGQAU+HoJ3x+PwmXP8wgV8umX/8vr+OIyACmwtGPnDFlNsuHLODsQy+yacV/ex1HRAYoFY5+5swv/gsVlkvSy9+gpbnJ6zgiMgCpcPQzGVk57D3vAUYFd7LyuX/yOo6IDEAqHP3QtPk3sTr1XM7a+lMO7N7qdRwRGWBUOPohS0hgyI3/AcD+Z+/2OI2IDDR+rwNIzwwdMY4Pzvgq537yCMuef4hzrv87ryOJSLAVAo0QaIJAE8GWRlqaG2hpbiLQ0kxrSzOtLU0EWppoDTQRbG6mNdBMMNCMa20h2NqMC7TgWv/6orUFF2yB1kBo/cEAFgyAC0BrAHOh6RYM0JqYwZl3/CrmH9OTwmFmi4Fx4dFBQLVzbmqE5e4FbgUcsBa42TnX2GdB49yMG/+Bjx96j5nr/n9WZeYx/ZJFXkcSiW/OEWw+ytG6KpqO1NJ4pIbmhjoCR2tpaagj2FRHa0Mdrrkea66HlgYs0EBCoIGEQCP+1kb8wQb8rU0kBhtJco34XQuJroUkmvHTeszmEoDk8OtUBFwCrfhowUcrCQTw/XXcJdBqofEGX84pbik6nhQO59wNbcNm9hBQ03kZMxsO3A1MdM41mNlzwI3AU32VM94lJiYx9q7fsfXhizjz/b9jXXoOZ8650utYIjHjgkEajtZSV32IozWVNNRU0nzkMC31VQSPVuEaqrCmWnzNdSS21JEUqCc5WE9K61HS3BHS3VESrZUMIOMk22pyiRwlmUaSaCCFZkumMSGZZkuhJSGLQGIKrQkptPqScb4kgr5knC8ZfMk4fzLmTwJ/CuZPJsGfhPmTSOgw7EtMwudPJiExGZ8/EZ8/iYTEJPz+JHx+P/7EJHz+JPyJiST6/fgSDH+C4Usw0hIS2scTEqwvdv0xPG2qMjMDFgDzuljED6SaWQuQBuzrq2z9RWp6JkNvf4m9j17AyKW3sSV9EGOnf9brWCJRccEgNZXlVFeUUV+5j6bagwTqKnBHKrGGwyQ2VpLcXE1aoIbMYDVZro40ayWti/UFnVFnaRyxdBosnUZfOtWJgwmkZhBIzCSYlIlLzsKSM7GUTHwpmSQkZ5KYlklSWhaJqVmkpGeRkpFFanIymYk+cnw6FdyZ1+c45gDlzrnjLg1yzu01sx8Bu4EG4HXn3Ot9HbA/yM4toPnWl6h5/CIKXrqJXel/ZMS441r+RPpMW0Go3L+d+oO7aTy8B1d7gISj5SQ3HCKtpZKswGFyXDWDrJVBnd4fdEaNZVBnWRzxZ1OdMpyK5DNpTcmB1BwS0nLwp+eQlJFLSmYeaVn5ZAzKJyM7h2yfj2xPPvXAYc652KzYbClQGGHWt51zL4aX+SmwzTn3UIT35wBLgBuAauB54AXn3NNdbO824DaAkpKSGbt27eqVz9GflG1bR8rTn6cVH+6W1ygsGeN2JKFqAAARuElEQVR1JDlNNTc2UL5nK9V7t9JQsYNg9R589ftJazhAdstB8oOHSLGWY97T6owqy6bGl0t9Yh7NKfkE0gqwjCEkZheSkjOMjJwhZOYVkpVTgD8xyaNPNzCZ2Urn3Myolo1V4Tjphs38wF5ghnOuLML864FLnHNfDo//DXCuc+6Ok6175syZbsWKFb0duV/YtvZ9Br9wDdW+HDK++ga5g4d7HUn6IRcMcrhiLwd3rqd+/zZaK3fiq91NesNe8pr3U+AOk2B//e0IuAQOWS7ViQXUpxTSkjYUyx5OUm4x6QUl5BSOJHfwcPyJiR5+KjmR7hQOL5uqLgQ2RSoaYbuBc80sjVBT1QXAwKwG3XDG5PPYUP9zRr36JfY8diVJd79BRlbfXGkh/U9ddSXlO9ZTXbaRwMGt+Gt2kH10F4WBMvJoIC+8XNAZFZZLZeJQdmfPZHvWCHx5pWQMGUVu0VjyC0soTEyM2MQgpx8vC8eNwDMdJ5jZMOAJ59ylzrllZvYCsAoIAB8Bj/V9zP5n4nmfY/WRH3Pmn+9g039exZh7XyE5pavTiTIQVFXsZ//Wj6grWwcVm0mv3UZh007yqSYzvEzQGQcSCjiUXMz6QZdC3hmkFo4lp2gsQ4rPYEhKGkM8/RQSLzxrqoqlgdxU1dHy3/8nZ6/+e1alz2Hy15eQmHSqV5NLvKutrmTv5hXU7lwNFZvIrN1KYfMucqltX6bepbI3sYTajFEEcseQPGQsuSUTKCydQEpquofpxUv9palKYuzsq77GB0cPc+6WH7HlXz9N2o2/oOiMM72OJb2gNRCg7JN1HPpkJc1715JatYkhR7cxlAqywsvUujT2JY1gW85nCOaPI234JAaPnsKQ4aMYl6BLTKXndMQxAKx8+ReM+fDb+F2AdVP/gbOvvBPTD0e/0XCkjt0bl1O9fQV2YA05tZsobtnZftVSwCWwx1dEZfoYWvInkFZ8FkPGzGDI8FH6niVq/eKqqlhS4TjegT3bqPzVzUxqXsOqjM8y+ubHyc5Ti3W8qak6xJ4N71O/YyX+g2vJr99McWsZvvAVTDWksyd5DPWDxuMbOpmckdMoGjtVTUxyylQ4VDgiag0EWP6bB5jxyX9y2AZRMf8Rzpx9udexBqyawxXsWf8e9TtWkHhwDYVHNjLclbfPP0gu+1LH0pg3iaTiaRSOm8XQkjE6ipCYUOFQ4Tihrav/TMqLtzE8uJ9lw77EjEU/JCk5xetYp7WaqkOUrfsLdV0UiX02mANp42kaPJn0ETMYPuEc8oYUeZhYBhoVDhWOkzpaX8PaX9zFOZUvss03mqQbfk7JWHVT0hvqa6vYte596rd/iL/8Y4bUb6TI7W+f37FIZJTOpHjSpxiUrzsgxFsqHCocUfvo9acpfe9bpLpGPi64nGEX30PxmClex+o36mur2L1hGbXbl+M/8DEF9Rspbt3bflf1AQrYlz6e5oKzSB85k6KJ55FTMNTj1CLHU+FQ4eiWin072fHcfUyteh0/raxJPxf/7K8x6bzPqz29g7qaw+xe/wF1O5bjL1/D4PqNFLXuay8SB8llb9p4GgvOIq00VCTU3CT9hQqHCkePHDqwm61/eoTxe54jh1o+8Y3i8ORbmfK5Lw+ocyAuGOTQgd3s27yco7s/IunQBgbXb6bY/bVX/3Ly2Jc2LlQkRkxj+MRPkV9Y4mFqkVOjwqHCcUoaj9az5pXHGbz+SUqDe6ggh22lNzL+818/7ZpZWpqbKNu2hsptKwnsW0N61QaGN31yzJ3W+2ww5WljaSyYTNqIGTqSkNOSCocKR69wwSBr3/kdfPATzmpcQbPz8UnSeKoHzyJj3FxGTz+ftIz+8eSDxoYj7PtkHYd3rSGwfyNJVVvJbdjB8NZ9JFrocZ9NLpHd/hFUZY4lOGQyWaXTGD7+bLJz8j1OLxJ7KhwqHL1u58YV7H/nF+RVfMiolm34LUiL8/FJ0jiqCs4mfexnGT3jAtIzOz+Sp+8cqaumomwb1fu20VSxA1e1i+S6XRQ07GBo8ED7TXStztiXMJRDqaU0DhpDYuFE8sfMpOiMs/QMCBmwVDhUOGKqvraK7Sv/myNb/4fcgx8yqmUridZKwCWw0z+SupShNKcOIZg5FP+g4aTmFZE1uIS8oaXdLiytgQC1VRXUV5VzpPoQjXWHaKk7ROuRSlz9QZLr9pDRuJ+CwAFyOjQvATS4JMp9hRxOG0lTzhiSCieQWzqZoaPO1J3WIp2ocKhw9KkjddVs/+gt6je/TcahNWS1VJDbeohMazhu2TqXSk3CIBzWPs1Zh+HwdL8LkOnqyOJIl9ttdn7KEwZTlTyUhrThBLNLSMwvJXPIaPKKxpA3eLiuChOJkgqHCkdcOFJXTeX+ndRW7KGxsoyW6n0k1O3D11iF4YDwv70O/wYtPC1oflqTswmm5mJpufjT80jMzCM1u4D0QQWhR4xm5ZDg8/X9BxM5DalbdYkL6ZmDSM+cCrojXeS0ouN4ERHpFhUOERHpFhUOERHpFhUOERHpFhUOERHpFhUOERHpFhUOERHpFhUOERHpltPyznEzqwB29fDt+cChXozTF/pb5v6WF5S5r/S3zP0tL3SdeYRzriCaFZyWheNUmNmKaG+7jxf9LXN/ywvK3Ff6W+b+lhd6J7OaqkREpFtUOEREpFtUOI73mNcBeqC/Ze5veUGZ+0p/y9zf8kIvZNY5DhER6RYdcYiISLcMyMJhZpeY2WYz22Zm34owf5GZVZjZ6vDrVi9ydsr0czM7aGbruphvZvYf4c+0xsym93XGTnlOlvd8M6vpsI+/29cZI2QqNrO3zGyDma03s69HWCbe9nM0meNmX5tZipl9aGYfh/M+EGGZZDNbHN7Hy8ystO+THpMnmsxx95sBYGY+M/vIzP4YYV7P97NzbkC9AB/wCTAKSAI+BiZ2WmYR8KjXWTtl+gwwHVjXxfxLgVcAA84FlsV53vOBP3q9XztlGgpMDw9nAlsi/NuIt/0cTea42dfh/ZYRHk4ElgHndlrmDuBn4eEbgcX9IHPc/WaEc30D+E2k7/9U9vNAPOKYBWxzzm13zjUDzwJXepzppJxz7wCHT7DIlcB/uZAPgEFmNrRv0h0virxxxzm33zm3KjxcB2wEhndaLN72czSZ40Z4v9WHRxPDr84nWq8EfhkefgG4wKzDg+n7WJSZ446ZFQGfB57oYpEe7+eBWDiGA3s6jJcR+X+0a8NNES+YWXHfRDsl0X6ueHJe+PD/FTOb5HWYjsKH7dMI/XXZUdzu5xNkhjja1+Hmk9XAQeAN51yX+9g5FwBqgLy+TXmsKDJD/P1mPAx8Ewh2Mb/H+3kgFo5o/AEodc6dBbzBX6uy9J5VhLo4mAL8GPi9x3namVkGsAS4xzlX63WeaJwkc1zta+dcq3NuKlAEzDKzM73ME40oMsfVb4aZXQYcdM6tjMX6B2Lh2At0/GugKDytnXOu0jnXFB59ApjRR9lOxUk/VzxxztW2Hf47514GEs0s3+NYmFkioR/gXzvnfhthkbjbzyfLHK/72jlXDbwFXNJpVvs+NjM/kA1U9m26yLrKHIe/GbOBK8xsJ6Hm+Hlm9nSnZXq8nwdi4VgOjDGzkWaWROik0EsdF+jUZn0FoXbjePcS8Dfhq37OBWqcc/u9DtUVMytsa081s1mE/i16+uMQzvMksNE5929dLBZX+zmazPG0r82swMwGhYdTgfnApk6LvQT8bXj4OuBNFz6D64VoMsfbb4Zz7j7nXJFzrpTQb9ybzrkvdlqsx/vZ32tJ+wnnXMDM7gReI3SF1c+dc+vN7HvACufcS8DdZnYFECB0gneRZ4HDzOwZQlfH5JtZGXA/oZN0OOd+BrxM6IqfbcBR4GZvkoZEkfc64HYzCwANwI1e/jiEzQa+BKwNt2cD/D1QAvG5n4kuczzt66HAL83MR6iAPeec+2On//+eBH5lZtsI/f93o0dZ20STOe5+MyLprf2sO8dFRKRbBmJTlYiInAIVDhER6RYVDhER6RYVDhER6RYVDhER6RYVDokpM7vKzJyZje8wrdTMvtCL2/iemV3Yw/c+ZWbXhYefMLOJJ1h2kZkN62nOU2Vm95jZ33QY94d7ZP1BDLeXFqN1F5jZq7FYt8SeCofE2kLg3fB/25QCvVY4nHPfdc4t7YX13Oqc23CCRRYBnhSO8J29txDq6bTNfEK94V4fo04A7wEiFo7wPQ095pyrAPab2exTWY94Q4VDYibcf9KngS9z7M1FPwDmWOi5Bfda6HkHvzCztRZ6dsDc8PsXmdnvzewNM9tpZnea2TfCy3xgZrnh5ToeNZxtZu+FO/T70MwyO2UyM3vUQs9jWQoM7jDvbTObaaEO7Z4ys3XhTPeG1z8T+HU4d6qZfdfMloeXe6zD3dlvm9m/hLe/xczmhKf7zOxH4eXXmNld4ekzzOx/zGylmb1mkXvbnQesCndG12Yh8AiwGzivw+fYaWYPmNmqcP7x4ekF4X25Pnx0tcvM8s0s3cz+FN5n68zsBjO7m1CRfMvM3gq/v97MHjKzjwl1mnhB+LtYa6HnryR32P4/h/fTCjObHv5cn5jZVzvk/z1w00n+GUk86o0+3/XSK9KL0I/Ck+Hh94AZ4eHz6fB8AODvCN3BDzCe0A9hCqG/8LcRes5EAaHeO78aXu7fCXXoB/AUobujk4DtwNnh6VmAv1Omawh1Qucj9MNYDVwXnvc2oeIwg1APqG3vGdRxfofpuR2GfwVc3mG5h8LDlwJLw8O3E+q+2t/2fkJ3078HFISn3dC2LzrlfgC4q8N4CrAPSAVuA37cYd7OtmUJPXPhifDwo8B94eFLCHUNng9cCzze4f3ZHdaT32G6AxZ02P4eYGx4/L86fB87gds7fE9rOnyH5R3WNxxY6/W/U726/9IRh8TSQkIdrBH+78Iulvs08DSAc24TsAsYG573lnOuzoWaNmoI9UIKsJZQk1dH44D9zrnl4XXVumP/QofQA6aecaHeTvcBb0bIsx0YZWY/NrNLgK56yJ1roSenrSV0RNCxu/K2zgZXdsh5IfB/2zI55w6HM58JvGGhLkP+gVDHiZ0NBSo6jF9GaN80EOrg8KpOzUeRtv9pwt+Hc+5VoCo8fS0wP3yUNMc5V9PF520Nb4tw7h3OuS3h8V8S2rdt2vp/W0voYVdt32GThft9ItRFuWfnjKTnBlxfVdI3ws1I84DJZuYI/YXvzOx/d3NVTR2Ggx3Gg8To369zrsrMpgAXA18FFhA6v9DOzFKAnxA6AtljZv9I6K/wzrlbT5LTgPXOufNOsAyE+pjquP6FwKct1PsphJ6jMI/Q0VR3to9zbouFHoF7KfB9M/tv59z3Iiza6JxrPUnONh2/p87fYVueFEKfS/oZHXFIrFwH/Mo5N8I5V+qcKwZ2AHOAOkJNF23+TLit28zGEuqgb3MPtrkZGGpmZ4fXlRk+qdzRO8AN4fMNQ4G5nVdioS7HE5xzSwgdAbQ9V7xj7rYf8UPhcznXRZHvDeD/a8sULq6bgQIzOy88LdEiP2hpI3BGeJksQvuxJLxvS4Gv0fURXZu/ECqCmNlFQE54eBhw1Dn3NPDDLj5vZ5uBUjM7Izz+JeB/TrL9zsYCEZ9JL/FNhUNiZSHwu07TloSnrwFawydj7yX0l3tCuMlnMbDI/fXZBlFzoUcB3wD8OHwC9w2O/SudcKatwAZC7fLvR1jVcODtcNPR08B94elPAT8LT28CHif0w/caoe76T+YJQudv1oTzfSGc+TrgX8LTVgOfivDeV/hrU9DVhLrA7riPXgQubztB3YUHgIvMbB1wPXCAUHGYDHwY/lz3A98PL/8Y8GrbyfGOnHONhHoGfj78vQWBn51sB3QyF/hTN98jcUC944r0E2b2O+CbzrmtPXx/MtDqQo8WOA/4qQs91c4TZvYOcKVzruqkC0tc0TkOkf7jW4ROkveocBBqAnzOzBKAZuArvRWsu8ysAPg3FY3+SUccIiLSLTrHISIi3aLCISIi3aLCISIi3aLCISIi3aLCISIi3aLCISIi3fL/AHSF0FilM8awAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEKCAYAAAAB0GKPAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8li6FKAAAgAElEQVR4nO3dd3xc9Znv8c+jmVHvxZasYtlGrrgXcBwn2GBDHHqxcYBd4xBuINTsvbmwWcLCDbvsBnZhwyYsJZANzRgnQAjVAZYQG+Peuy3bsmRZklWtOjO/+8ccibEYySNZM2dkPe/Xa16cNud854yZR+d3zvkdMcaglFJKnU6U3QGUUkr1D1owlFJKBUULhlJKqaBowVBKKRUULRhKKaWCogVDKaVUUGwpGCKyTEQ2Wa9iEdnUxXKXiMhuEdknIveFO6dSSqmviN33YYjI40CtMebhTtMdwB5gHlACrAUWG2N2hD+lUkopW5ukRESAhcCrAWbPAPYZYw4YY1qB14ArwplPKaXUV5w2b382UG6M2RtgXi5wxG+8BDgvmJVmZmaawsLCM0+nlFIDxPr16yuNMVndLROygiEiK4HsALN+aox5yxpeTOCji95s71bgVoCCggLWrVvXF6tVSqkBQUQOnW6ZkBUMY8xF3c0XESdwNTC1i0WOAvl+43nWtK629wzwDMC0adO0gyyllOpjdp7DuAjYZYwp6WL+WqBIRIaJSDRwPfB22NIppZQ6hZ0F43o6NUeJyBAReRfAGOMG7gA+AHYCrxtjtoc9pVJKKcDGk97GmCUBppUCC/zG3wXeDWMspVQfa2tro6SkhObmZrujKCA2Npa8vDxcLleP32v3VVJKqbNcSUkJSUlJFBYW4ruSXtnFGENVVRUlJSUMGzasx+/XrkGUUiHV3NxMRkaGFosIICJkZGT0+mhPC4ZSKuS0WESOM/kutGBYPG43X/z279n6P7+3O4pSSkUkLRiWKIeDsQdfpHHLW6dfWCnVbzgcDiZNmtTxevTRR/ts3Zs2beLddwNfl/Ppp5+SkpJyyrZXrlzZZ9u2g570togI5c4hxDcctjuKUqoPxcXFsWlTwA6xz9imTZtYt24dCxYsCDh/9uzZvPPOO326TbfbjdNpz0+3HmH4qY3LJ721y5vJlVJnidraWkaNGsXu3bsBWLx4Mc8++ywAt912G9OmTWPcuHE8+OCDHe9Zu3Yt3/jGN5g4cSIzZsygtraWn/3sZyxbtoxJkyaxbNmyoLZdXFzMmDFj+MEPfsC4ceOYP38+TU1NAOzfv59LLrmEqVOnMnv2bHbt2gXAkiVL+OEPf8h5553HT37yEyoqKpg3bx7jxo3jlltuYejQoVRWVvKzn/2MJ554omNbP/3pT3nyySf7ZJ+BHmGcoi15KNl1n9DW2owrOtbuOEqddR7643Z2lNb16TrHDknmwcvGdTm/qamJSZMmdYzff//9LFq0iKeeeoolS5Zw9913U11dzQ9+8AMAHnnkEdLT0/F4PFx44YVs2bKF0aNHs2jRIpYtW8b06dOpq6sjPj6ehx9+mHXr1vHUU08F3PZf/vKXU7a9YsUKHA4He/fu5dVXX+XZZ59l4cKFrFixghtvvJFbb72Vp59+mqKiItasWcPtt9/Oxx9/DPguT161ahUOh4M77riDuXPncv/99/P+++/z/PPPA7B06VKuvvpq7rnnHrxeL6+99hpffvnlGe/jdlow/DgyR+A4aig7vJe8c8bbHUcp1Qe6apKaN28ey5cv50c/+hGbN2/umP7666/zzDPP4Ha7KSsrY8eOHYgIOTk5TJ8+HYDk5OSgth2oSaq4uJhhw4Z1FJKpU6dSXFxMQ0MDq1at4rrrrutYtqWlpWP4uuuuw+FwAPD555/zhz/8AYBLLrmEtLQ0AAoLC8nIyGDjxo2Ul5czefJkMjIygsoaDC0YfhJzimAznDiyWwuGUiHQ3ZFAuHm9Xnbu3El8fDzV1dXk5eVx8OBBHnvsMdauXUtaWhpLliwJyR3qMTExHcMOh4Ompia8Xi+pqaldnm9JSEgIat233HILL774IseOHWPp0qV9krednsPwM6hgDABN5YEez6GUOpv8+7//O2PGjOGVV17h5ptvpq2tjbq6OhISEkhJSaG8vJz33nsPgFGjRlFWVsbatWsBqK+vx+12k5SURH19fZ/kSU5OZtiwYSxfvhzw3ZXtf+Tjb9asWbz++usAfPjhh1RXV3fMu+qqq3j//fdZu3YtF198cZ9ka6cFw09Gdj6NJgZz4qDdUZRSfaT9HEb767777mP37t0899xzPP7448yePZtvfetb/PznP2fixIlMnjyZ0aNH873vfY9Zs2YBEB0dzbJly7jzzjuZOHEi8+bNo7m5mTlz5rBjx44uT3q3n8Nof73xxhvdZn355Zd5/vnnmThxIuPGjeOttwJf5v/ggw/y4Ycfcu6557J8+XKys7NJSkrqyDpnzhwWLlzY0YTVV2x/pncoTJs2zfT2AUoHH55IbUw2k/7vB32cSqmBaefOnYwZM8buGGeVlpYWHA4HTqeT1atXc9ttt3U0ZXm9XqZMmcLy5cspKioK+P5A34mIrDfGTOtuu3oOo5OauDzSm4rtjqGUUl06fPgwCxcuxOv1Eh0d3XFJ8I4dO7j00ku56qqruiwWZ0ILRictSUPJafgCj9uNw6abY5RSqjtFRUVs3Ljxa9PHjh3LgQMHQrZdPYfRiWQMJ1rcVJTqeQyllPKnBaOThGzfYVzl4Z02J1FKqciiBaOTjILRADQe22dzEqWUiixaMDoZlDuCVuPAU7Xf7ihKKRVRtGB04nA6OebIJrbukN1RlFJnaM6cOXzwwamXyD/xxBPcdtttAGzfvp25c+cyatQoRowYwYMPPojX6wXgxRdfJCsr65T7KHbs2PG1bYSy+/RIo5cBBXAiJo/k5hK7YyilztDixYt57bXXTrnj+bXXXuNf//VfaWpq4vLLL+fXv/418+fPp7GxkWuuuYYnn3ySe++9F6Cjk8LuhKL7dDu7MO+OHmEE0JxYQI67FGP9paGU6p+uvfZa/vSnP9Ha2gr4Ov4rLS1l9uzZvPLKK8yaNYv58+cDEB8fz1NPPcUvfvGLPtl2YWEhDz74IFOmTGH8+PEdXZWfPHmSpUuXMmPGDCZPntxxN/eLL77I5Zdfzty5c7nwwgvxer3cfvvtjB49mnnz5rFgwQLeeOMNPv74Y6688sqO7Xz00UdcddVVfZL5dCKvhEWC9OHEV7RQefwomdn5dqdR6uzx3n1wbGvfrjN7PHwncDNQeno6M2bM4L333uOKK67gtddeY+HChYgI27dvZ+rUqacsP2LECJqamqipqQFg2bJlfP755x3zV69eTVxc3Cnv6ar7dIDMzEw2bNjAr371Kx577DGee+45HnnkEebOnctvfvMbampqmDFjBhdddBEAGzZsYMuWLaSnp/PGG29QXFzMjh07OH78OGPGjGHp0qXMmTOH22+/nYqKCrKysnjhhRf6vJPBrugRRgBxg61Law/ppbVK9XftzVLga45avHhx0O9dtGgRmzZt6nh1LhbwVZNU+6u9WABcffXVwFddmIOvs8BHH32USZMmccEFF9Dc3Mzhw74nfc6bN4/09HTA14X5ddddR1RUFNnZ2cyZMwfwPR30pptu4qWXXqKmpobVq1fzne98p+c7phf0CCOA9PyRANSX7QHm2xtGqbNJF0cCoXTFFVdw7733smHDBhobGzuOKsaOHctnn312yrIHDhwgIyOD1NTUPtl2ezfmDocDt9sN+HqhXbFiBaNGjTpl2TVr1gTdhfnNN9/MZZddRmxsLNddd13YznfoEUYAgwtG4TGCpzJ0t9grpcIjMTGROXPmsHTp0lOOLm644QY+//xzVq5cCfialu666y4eeuihkOa5+OKL+eUvf0l7x6+BuvgAXxfmK1aswOv1Ul5ezqefftoxb8iQIQwZMoSf//zn3HzzzSHN608LRgDRMbGUR2XhrC22O4pSqg8sXryYzZs3n1Iw4uLiePvtt3nkkUcYOXIkmZmZzJo1ixtuuKFjmfbndbe/Vq1a9bV1B+o+vTsPPPAAbW1tTJgwgXHjxvHAAw8EXO6aa64hLy+PsWPHcuONNzJlyhRSUlI65t9www3k5+eHtSdg7d68C1v/+QJiPCcZ+Q9r+yiVUgNTf+ne/M033+THP/4xn3zyCUOHDrU7DgANDQ0kJiZSVVXFjBkz+Otf/0p2djYAd9xxB5MnT+b73/9+j9er3Zv3scbEoeRXrbQ7hlIqTK688spTLleNBJdeeik1NTW0trbywAMPdBSLqVOnkpCQwOOPPx7WPFowumDSCkmtaqC2qpyUjMF2x1FKDUD+5y38rV+/PrxBLHoOowsxg3yX1pYf2mVzEqX6v7Ox6bu/OpPvQgtGF1LzfJe81ZXtsTmJUv1bbGwsVVVVWjQigDGGqqoqYmNje/V+bZLqQvZQXzfnbce1m3OlzkReXh4lJSVUVFTYHUXhK+B5eXm9eq8WjC7EJSRxnHS9tFapM+RyuRg2bJjdMVQf0CapblRG55J48ojdMZRSKiJowehGQ3w+WW1H7Y6hlFIRQQtGN7ypw8ikhsaGWrujKKWU7bRgdMOZNQKAY8V6aa1SStlSMERkmYhssl7FIvK1x1WJSL6IfCIiO0Rku4jcHe6cKbm+Xmtrj2rBUEopW66SMsZ0dBgvIo8Dgdp83MDfGWM2iEgSsF5EPjLGfP2huiEyaKivr5WW4/vDtUmllIpYtl5WKyICLATmdp5njCkDyqzhehHZCeQCYSsYKWmZVJOEVB8M1yaVUipi2X0OYzZQbozZ291CIlIITAbWhCHTKY47h5Bw8nC4N6uUUhEnZEcYIrISyA4w66fGmLes4cXAq6dZTyKwArjHGFPXzXK3ArcCFBQU9CpzIPXx+eTWbe6z9SmlVH8VsoJhjLmou/ki4gSuBqZ2s4wLX7F42Rjz+9Ns7xngGfA9D6PHgbvQllLI4No/09LcSExsfF+tViml+h07m6QuAnYZY0oCzbTObzwP7DTG/FtYk/lxZo4gSgzHDmknhEqpgc3OgnE9nZqjRGSIiLxrjc4CbgLm+l2CuyDcIZOG+C6trdFLa5VSA5xtV0kZY5YEmFYKLLCGPwckzLG+JqvA12tt0zHttVYpNbDZfZVUxEvPGkKDidNLa5VSA54WjNOQqCiOOYcQW3/I7ihKKWUrLRhBqIvLJb1Fe61VSg1sWjCC0JJcyGBvOe62VrujKKWUbbRgBMGRMYJo8XC85IDdUZRSyjZaMIKQkF0EQNWRnTYnUUop+2jBCELmUN+ltY16aa1SagDTghGErJxCmo0LU6XdnCulBi4tGEGIcjg45sgmRi+tVUoNYFowglQdm09qs15aq5QauLRgBKklqYBsTxlej8fuKEopZQstGEGS9OHESSuVx/RhSkqpgUkLRpDirUtrKw9rr7VKqYFJC0aQ0vNHAXCyTJ+LoZQamLRgBGlwfhFtxoG7Ui+tVUoNTFowguR0RVMeNYjoOr20Vik1MGnB6IETMbmkNB2xO4ZSStlCC0YPNCUWMMhThvF67Y6ilFJhpwWjB0z6cJJppKaq3O4oSikVdloweiB20DkAlB/aYXMSpZQKPy0YPZCW57u0tqF0r81JlFIq/LRg9MDgoaPwGMF9XO/FUEoNPFoweiA2LoEjjnziqrbZHUUppcJOC0YPVSSNJbdpt14ppZQacLRg9JA3ZxKZ1HC89KDdUZRSKqy0YPRQyjkzACjdsdrmJEopFV5aMHqocOx5uE0UzYfW2R1FKaXCSgtGD8XGJ3LIOZSEqq12R1FKqbDSgtELVcljyW/WE99KqYFFC0YvmJzJpFFP2WG9gU8pNXBoweiF9KLzADi2c5XNSZRSKny0YPRCwZhptBoHLYc32B1FKaXCRgtGL8TExnPIOYykE1vsjqKUUmGjBaOXTqSOo6Blj574VkoNGFowekmGTCaZRo4e0K7OlVIDgxaMXspoP/G9W+/4VkoNDFoweqlg9FRajAv34fV2R1FKqbDQgtFLrugYil3DSarWrs6VUgODLQVDRJaJyCbrVSwim7pZ1iEiG0XknXBmDEZN6jgKW/bi9XjsjqKUUiFnS8EwxiwyxkwyxkwCVgC/72bxu4Gd4UnWM5I7hQRp5sg+7VdKKXX2s7VJSkQEWAi82sX8POC7wHPhzBWsrFHnA1ChJ76VUgNAUAVDRH4vIt8Vkb4uMLOBcmNMV50yPQH8BIjImx3yiybSaGJwl+gd30qps1+wBeBXwPeAvSLyqIiMOt0bRGSliGwL8LrCb7HFdH10cSlw3BgT1GVIInKriKwTkXUVFRXBvOWMOV3RHIoeQYqe+FZKDQDOYBYyxqwEVopICr4f+ZUicgR4FnjJGNMW4D0XdbdOEXECVwNTu1hkFnC5iCwAYoFkEXnJGHNjFxmfAZ4BmDZtmgnmc/WF2rTxTCh/E3dbK05XdLg2q5RSYRd0E5OIZABLgFuAjcCTwBTgo15u+yJglzGmJNBMY8z9xpg8Y0whcD3wcVfFwk7OvCnESwtH9m62O4pSSoVUsOcw/gD8BYgHLjPGXG6MWWaMuRNI7OW2r6dTc5SIDBGRd3u5PlsMGt1+4vsLm5MopVRoBdUkBfyHMeaTQDOMMdN6s2FjzJIA00qBBQGmfwp82pvthFreiPE0mDjMUT3xrZQ6uwVbMNJE5OpO02qBrcaY432cqV+Jcjg4FFNEas12u6MopVRIBVswvg/MBNqPMi4A1gPDRORhY8zvQpCt36hPH8/kstdpa23BFR1jdxyllAqJYE96u4AxxphrjDHXAGMBA5wH/N9QhesvXPlTiJE2Du/SjgiVUmevYAtGnjGm3G/8OJBvjDkBfO2S2oEme8xMAKr26IlvpdTZK9gmqU+tzv+WW+PXWNMSgJqQJOtHhhSOoY4ETOlGu6MopVTIBFswfoTvJrtvWuP/DawwxhhgTiiC9ScSFcWhmJFk1OqJb6XU2eu0BUNEHMBKY8wcfD3LqgAaMsYz6ujLNDedJDYuwe44SinV5057DsMY4wG8VrcgqgsxBVOJFg+Hd66zO4pSSoVEsE1SDcBWEfkIONk+0RhzV0hS9UM5Y2bCF1C9bw1M+bbdcZRSqs8FWzB+T/cPORrwsvOLqCYZ0RPfSqmzVLC91f5WROKAAmPM7hBn6pckKoojsaPIrNthdxSllAqJYDsfvAzYBLxvjU8SkbdDGaw/Opk5ngLPYZpO1tsdRSml+lywN+79IzAD654LY8wmYHiIMvVbsQVTcYqXQzvW2B1FKaX6XLAFo80YU9tpWkQ+NtVOueNmAVCz70ubkyilVN8L9qT3dhH5HuAQkSLgLmBV6GL1T1k5Q6kkFcexTXZHUUqpPhfsEcadwDigBd9Dj+qAe0IVqr+SqChK4kaTVa8nvpVSZ59gr5JqBH5qvVQ3mrImMOHQGk7W15CQlGp3HKWU6jPBXiU1UkSeEZEPReTj9leow/VH8YVTiRLDoe3ac61S6uwS7DmM5cDTwHOAJ3Rx+r/csbPgM6jbuwrOv8TuOEop1WeCLRhuY8yvQ5rkLJGZnc/BqKEkHfnU7ihKKdWngj3p/UcRuV1EckQkvf0V0mT92LHB32ZkyzbqaqrsjqKUUn0m2ILxt8D/wXcp7Xrrpd2ydiFl4ndxiYd9q/VmeKXU2SOogmGMGRbgpXd6d2Hk1LnUkoBn9wd2R1FKqT7TbcEQkZ/4DV/Xad4/hSpUf+d0RbMv6TyG16zC69FrBJRSZ4fTHWFc7zd8f6d5eglQN0zRfDKoZd/mz+2OopRSfeJ0BUO6GA40rvyMmHklXiNUbfyj3VGUUqpPnK5gmC6GA40rP2lZOexxjSaz7FO7oyilVJ84XcGYKCJ1IlIPTLCG28fHhyFfv1addwFF7r1UHjtsdxSllDpj3RYMY4zDGJNsjEkyxjit4fZxV7hC9leDplwOwIHVb9qcRCmlzlyw92GoXhh+7vkcJx3nvo/sjqKUUmdMC0YISVQUxemzGNmwltaWZrvjKKXUGdGCEWKu0ZeQKE3sWfuh3VGUUuqMaMEIsZEzL6XVOGnY+q7dUZRS6oxowQixhKRUdsVNZEjFZ3ZHUUqpM6IFIwwah15IgfcoRw9stzuKUkr1mhaMMMg/70oAjqzRy2uVUv2XFowwyB0+jsNRucQf+rPdUZRSqte0YIRJada3GN20mZP1NXZHUUqpXrGlYIjIMhHZZL2KRWRTF8ulisgbIrJLRHaKyMxwZ+0rieMXEC1u9qx+x+4oSinVK7YUDGPMImPMJGPMJGAF8PsuFn0SeN8YMxqYCOwMV8a+NnL6fBpMHG273rc7ilJK9YrTzo2LiAALgbkB5qUA3wKWABhjWoHWcObrS9ExsWxLnE7hib9ivF4kSlsDlVL9i92/WrOBcmPM3gDzhgEVwAsislFEnhORhPDG61vuc+YxiBMc2PaF3VGUUqrHQlYwRGSliGwL8LrCb7HFwKtdrMIJTAF+bYyZDJwE7utme7eKyDoRWVdRUdFnn6MvDZ/pu7z2+Ia3bU6ilFI9F7ImKWPMRd3NFxEncDUwtYtFSoASY8waa/wNuikYxphngGcApk2bFpEPd8rMLmCvs4i0kk/tjqKUUj1mZ5PURcAuY0xJoJnGmGPAEREZZU26ENgRrnChUplzASPbdlFdUWZ3FKWU6hE7C8b1dGqOEpEhIuLfS9+dwMsisgWYBPxTGPOFRMbky4gSw359qJJSqp+x7SopY8ySANNKgQV+45uAaWGMFXLnTPwmlW+nIns/BG6zO45SSgXN7qukBpwoh4ODqTMpql+Du63fXiWslBqAtGDYwDHqYpI5yZ71H9sdRSmlgqYFwwZF37iCJhNNw5rf2R1FKaWCpgXDBkkp6WzNuJjxJz6ktqrc7jhKKRUULRg2yZx7J3HSys53/9PuKEopFRQtGDYZfu557IgeT8GBV/G43XbHUUqp09KCYaPmyd9niDnO1k9etzuKUkqdlhYMG42/6AbKycCx7lm7oyil1GlpwbCRyxXNgcKFjG/ZwKHdAZ8hpZRSEUMLhs1GfucOWo2TYx89aXcUpZTqlhYMm2UMzmNz6lzOrXiX+toTdsdRSqkuacGIACnfvoMEaWb7u0/bHUUppbqkBSMCjJzybfY4R5K753d4PR674yilVEBaMCJE3YSl5JtStn/+lt1RlFIqIC0YEWL8/L+lihQ8X/yX3VGUUiogLRgRIiY2nj151zChcQ1HD+y0O45SSn2NFowIMuI7d+FFOPKBXmKrlIo8WjAiyKDcYWxJms3Y8rdpOllvdxyllDqFFowIE/vN20nmJFvf0+5ClFKRRQtGhBkzYz77o4aRteO3GK/X7jhKKdVBC0aEkagoqsb9LcO8xexc84HdcZRSqoMWjAg0/pJbqCWB5r/+yu4oSinVQQtGBIpLSGJn9pVMqP+cY0f22R1HKaUALRgRq+CSu32X2L7x93ZHUUopQAtGxBpSOIr1eTcxvfYDtv31j3bHUUopLRiRbPINj3BUBpOy8ie0NDfaHUcpNcBpwYhgsfGJVH37n8k3pWx45R/tjqOUGuC0YES4CRdcw/qkOUw59BuO7Ntqdxyl1ACmBaMfGLr4SVpxUrP8Tr2ZTyllGy0Y/UDmkKHsGHsP41s2sv5P2mWIUsoeWjD6iWnX/G/2OEcybP0j1J6osDuOUmoA0oLRTzicTqIue4JUU8eul/+33XGUUgOQFox+5JyJs1g7eCHTK99i17o/2x1HKTXAaMHoZ8698V+okHSi3/0xba0tdsdRSg0gWjD6mcTkNI7OfIjh3mLWv/5PdsdRSg0gWjD6ocnzbmBT3PlM2Ptrjh3ea3ccpdQAoQWjH5KoKAZf/x8AlL12l81plFIDhdPuAKp3coaO4otzfsj5+59kzfLHOe+6v7M7klLK6wF3M7hbwN2Ct62ZttYm2lpbcLe14mlrxdPWgrutBY+7BW9rKx53K153K8bThtfTinG3YTxfvfC0Ybxt4HH71u91I143GDd43IjxTRevG48rkXNv/13IPp4tBUNElgGjrNFUoMYYMynAcvcCtwAG2ArcbIxpDlvQCDf1+n9g8+OrmLbt/7EhKYMplyyxO5JSkc0YvK2NNNZX03KyjuaTtbQ21eNurKOtqR5vSz2epnpMawPS2gBtTYi7iSh3E1HuZpyeZpzeJpyeFlzeZqJNM07Thsu0EU0rTjynbC4KiLFeZ8JtovDgoA0HHqJw4/hq3EThEd94kyPtDLfUPVsKhjFmUfuwiDwO1HZeRkRygbuAscaYJhF5HbgeeDFcOSOdyxXNyDv/wN4n5nPu6r9jW0Ia586+wu5YSoWM8XppaqyjvqaSxtoqmmqraD15graGaryN1ZimaqSlDkdrPa62eqLdDcR4G4j1NBJvTpJgGnGJh0Qg8TTbajEuGomhmWiaiKVVYmiOiqFVYmmLSsbtisUTFYvHEYNxRON1xGAcMeCIwThjEGc0OGMRZwxRzmjEGU2U37DDFY3DGUOUKwaH04XDGU2UKxqnMxqH04nTFY3DGY3T5cLldOKIEpxRgiNKiI+K6hiPipJw7HrA5iYpERFgITC3i0WcQJyItAHxQGm4svUXcQlJ5Nz2NkefupBhK29lT0IqI6d82+5YSgXFeL3UVpVTU1FCQ1UpLXXHcddXYE5WIU0ncDVXEdNaQ7y7liRvDcmmnnjxEN/F+rxGqJd4TkoCTZJAsyOBGtcg3HGJuF1JeKOTMDHJSEwSEpuEIzaJqJgkXPFJRMcn44pLJjYhmdjEZOJiYkhyOUhz6Knednafw5gNlBtjvnapjzHmqIg8BhwGmoAPjTEfhjtgf5CSnkXrLW9T++x8st6+gUMJ7zB01Nda+JQKm/ZCUFV2gIbjh2k+cQRTd4yoxnJimiqJb6si2X2CNFNDqnhI7fR+rxFqJZF6SeakM4Wa2FwqYs7FE5sGcWlExafhTEgjOjGd2KQM4pMzSUzNJDEljRSHgxRbPvXZT4wxoVmxyEogO8Csnxpj3rKW+TWwzxjzeID3pwErgEVADbAceMMY81IX27sVuBWgoKBg6tLYAx4AABGeSURBVKFDh/rkc/QnJfu2EfvSd/HgwCz9gOyCIrsjqbNUa3MT5Uf2UnN0L00VB/HWHMHRUEZ80zFS2o6T6a0kVtpOeY/HCNWSQq0jnQZXBq2xmbjjs5DEwbhSsolNG0Ji2mCSMrJJTsvC6Yq26dMNTCKy3hgzrdtlQlUwTkdEnMBRYKoxpiTA/OuAS4wx37fG/wY43xhz++nWPW3aNLNu3bq+jtwv7Nu6mkFvXE2NI43EH35E+qBcuyOpfsh4vZyoOMrx4u00lO3DU1WMo+4wCU1HyWgtI8ucIEq++u1wmygqJZ0aVxYNsdm0xecgKblEp+eTkFVAWvYw0gfl4nS5bPxUqjvBFAw7m6QuAnYFKhaWw8D5IhKPr0nqQmBgVoEeOGf8THY0/Ibh79/EkWeuIPquj0hMDu2VE6r/qq+povzgdmpKduI+vhdn7UFSGg+R7S4hgyYyrOW8RqiQdKpcORxOmcaB5KE4MgpJHDyc9LyRZGYXkO1yBWxSUGcPOwvG9cCr/hNEZAjwnDFmgTFmjYi8AWwA3MBG4Jnwx+x/xs78DptO/pJz/3I7u/7zSorufY+Y2K5OE6qBoLqijLK9G6kv2QYVu0mo20d2SzGZ1JBkLeM1wrGoLCpj8tmeugAyziEueyRpeSMZnH8Og2PjGWzrp1B2s61JKpQGcpOUv7Vv/ifTN/09GxJmM/7uFbiiz/RqcBXp6mqqOLp7HXXFm6BiF0l1e8luPUQ6dR3LNJg4jroKqEscjju9iJjBI0kvGEN24Rhi4xJsTK/sFOlNUirEpl/5I75oPMH5ex5jz79+k/jrXyDvnHPtjqX6gMftpmT/Nir3r6f16FbiqncxuHEfOVSQbC1TZ+IpjR7KvrRv4c0cRXzuOAaNmMjg3OGMitJLRVXP6RHGALD+3Rco+vKnOI2bbZP+gelX3IHoD0a/0XSynsM711JzYB1ybAtpdbvIbyvuuArJbaI44sijKqGItswxxOdPYHDRVAbnDtfvWQUtoq+SCiUtGF937Mg+qn53M+Nat7Ah8duMuPlZUjK0RTrS1FZXcmTHahoOrsd5fCuZDbvJ95TgsK5IqiWBIzFFNKSOxpEznrRhk8kbOUmbktQZ04KhTuFxu1n7ykNM3f+fnJBUKuY9ybmzLrM71oBVe6KCI9tX0XBwHa7jW8g+uZNcU94x/zjplMaNpDljHNH5k8keNYOcgiI9alAhoQVDBbR301+IfetWcr1lrBlyE1OX/ILomFi7Y53VaqsrKdn2V+q7KA6lMohj8aNpGTSehKFTyR1zHhmD82xMrAYaLRiqS40NtWx94U7Oq3qLfY4RRC/6DQUjtTuRvtBQV82hbatpOPAlzvLNDG7YSZ4p65jvXxwSC6eRP+4bpGbqHQzKXlow1Glt/PAlClfdR5xpZnPWZQy5+B7yiybaHavfaKir5vCONdQdWIvz2GayGnaS7znacRf0MbIoTRhNa9YEEoZNI2/sTNKycmxOrdTXacFQQakoLebg6/czqfpDnHjYknA+zlk/YtzM72p7uZ/62hMc3v4F9QfX4izfwqCGneR5SjuKw3HSORo/muasCcQX+oqDNiup/kILhuqRymOH2funJxl95HXSqGO/Yzgnxt/CxO98f0Cd4zBeL5XHDlO6ey2NhzcSXbmDQQ27yTdf9a5fTgal8aN8xWHoZHLHfoPM7AIbUyt1ZrRgqF5pbmxgy3vPMmj78xR6j1BBGvsKr2f0d+8+65pT2lpbKNm3hap963GXbiGhege5LftPuTO6VAZRHj+S5qzxxA+dqkcO6qykBUOdEeP1svWzP8AXv2JC8zpajYP90aOpGTSDxFFzGDHlAuIT+8eTB5qbTlK6fxsnDm3BXbaT6Oq9pDcdJNdTikt8j9VsMS4OO4dSnTQS7+DxJBdOJnf0dFLSMm1Or1ToacFQfaZ45zrKPnuBjIovGd62D6d4aTMO9kePojprOgkjv82IqReSkNT5UTjhc7K+hoqSfdSU7qOl4iCm+hAx9YfIajpIjvdYx81vHiOURuVQGVdIc2oRruyxZBZNI++cCfoMBjVgacFQIdFQV82B9X/m5N7/If34lwxv24tLPLhNFMXOYdTH5tAaNxhvUg7O1FziMvJIHlRARk5hjwuKx+2mrrqChupyTtZU0lxfSVt9JZ6TVZiG48TUHyGxuYws9zHS/JqRAJpMNOWObE7ED6MlrYjo7DGkF44nZ/i5eme0Up1owVBhcbK+hgMbP6Fh96ckVm4hua2CdE8lSdL0tWXrTRy1UakYvnpwvRG/YWu607hJMvUkc7LL7bYaJ+VRg6iOyaEpPhdvSgGuzEKSBo8gI6+IjEG5epWXUkHSgqFsdbK+hqqyYuoqjtBcVUJbTSlR9aU4mqsRDGD92/P7NyjWNK848cSk4I1LR+LTcSZk4ErKIC4li4TULN+jPJPTiHI4wv/BlDoLaffmylYJSakkJE0CvYNcqbOCHq8rpZQKihYMpZRSQdGCoZRSKihaMJRSSgVFC4ZSSqmgaMFQSikVFC0YSimlgqIFQymlVFDOyju9RaQCONTLt2cClX0YJxz6W+b+lhc0c7j0t8z9LS90nXmoMSaruzeelQXjTIjIutPdHh9p+lvm/pYXNHO49LfM/S0vnFlmbZJSSikVFC0YSimlgqIF4+uesTtAL/S3zP0tL2jmcOlvmftbXjiDzHoOQymlVFD0CEMppVRQBmTBEJFLRGS3iOwTkfsCzF8iIhUissl63WJHzk6ZfiMix0VkWxfzRUT+w/pMW0RkSrgzdspzurwXiEit3z7+WbgzBsiULyKfiMgOEdkuIncHWCbS9nMwmSNmX4tIrIh8KSKbrbwPBVgmRkSWWft4jYgUhj/pKXmCyRxxvxkAIuIQkY0i8k6AeT3fz8aYAfUCHMB+YDgQDWwGxnZaZgnwlN1ZO2X6FjAF2NbF/AXAe4AA5wNrIjzvBcA7du/XTplygCnWcBKwJ8C/jUjbz8Fkjph9be23RGvYBawBzu+0zO3A09bw9cCyfpA54n4zrFw/Bl4J9P33Zj8PxCOMGcA+Y8wBY0wr8Bpwhc2ZTssY8xlwoptFrgD+2/h8AaSKSE540n1dEHkjjjGmzBizwRquB3YCuZ0Wi7T9HEzmiGHttwZr1GW9Op9IvQL4rTX8BnChiN+D38MsyMwRR0TygO8Cz3WxSI/380AsGLnAEb/xEgL/D3aN1eTwhojkhyfaGQn2c0WSmdZh/nsiMs7uMP6sw/PJ+P6a9Bex+7mbzBBB+9pqJtkEHAc+MsZ0uY+NMW6gFsgIb8pTBZEZIu834wngJ4C3i/k93s8DsWAE449AoTFmAvARX1Vh1Xc24OuKYCLwS+BNm/N0EJFEYAVwjzGmzu48wThN5oja18YYjzFmEpAHzBCRc+3ME4wgMkfUb4aIXAocN8as78v1DsSCcRTwr/551rQOxpgqY0yLNfocMDVM2c7EaT9XJDHG1LUf5htj3gVcIpJpcyxExIXvh/dlY8zvAywScfv5dJkjdV8bY2qAT4BLOs3q2Mci4gRSgKrwpgusq8wR+JsxC7hcRIrxNbvPFZGXOi3T4/08EAvGWqBIRIaJSDS+kz1v+y/QqU36cnztwpHubeBvrKt4zgdqjTFldofqiohkt7eXisgMfP8Wbf1RsPI8D+w0xvxbF4tF1H4OJnMk7WsRyRKRVGs4DpgH7Oq02NvA31rD1wIfG+vMrB2CyRxpvxnGmPuNMXnGmEJ8v3EfG2Nu7LRYj/ezs8+TRjhjjFtE7gA+wHfF1G+MMdtF5GFgnTHmbeAuEbkccOM7cbvEtsAWEXkV39UumSJSAjyI7+QbxpingXfxXcGzD2gEbrYnqU8Qea8FbhMRN9AEXG/nj4JlFnATsNVqrwb4e6AAInM/E1zmSNrXOcBvRcSBr3C9box5p9P/f88DvxORffj+/7vepqztgskccb8ZgZzpftY7vZVSSgVlIDZJKaWU6gUtGEoppYKiBUMppVRQtGAopZQKihYMpZRSQdGCoUJKRK4UESMio/2mFYrI9/pwGw+LyEW9fO+LInKtNfyciIztZtklIjKktznPlIjcIyJ/4zfutHpIfTSE24sP0bqzROT9UKxbhY4WDBVqi4HPrf+2KwT6rGAYY35mjFnZB+u5xRizo5tFlgC2FAzrTtyl+HoebTcPX++014Woc757gIAFw7onodeMMRVAmYjMOpP1qPDSgqFCxurf6JvA9zn1pqBHgdnie27AveJ73sALIrJVfH33z7Hev0RE3hSRj0SkWETuEJEfW8t8ISLp1nL+RwnTRWSV1dHelyKS1CmTiMhT4nseykpgkN+8T0Vkmvg6mntRRLZZme611j8NeNnKHSciPxORtdZyz/jdTf2piPyLtf09IjLbmu4Qkces5beIyJ3W9Kki8j8isl5EPpDAvd/OBTZYncS1Www8CRwGZvp9jmIReUhENlj5R1vTs6x9ud06mjokIpkikiAif7L22TYRWSQid+Erjp+IyCfW+xtE5HER2YyvM8MLre9iq/iefxLjt/1/tvbTOhGZYn2u/SLyQ7/8bwI3nOafkYokfdn3ur705f/C92PwvDW8CphqDV+AX//8wN/hu+MeYDS+H8BYfH/R78P3nIcsfL1p/tBa7t/xdbQH8CK+u5mjgQPAdGt6MuDslOlqfJ3DOfD9INYA11rzPsVXFKbi65G0/T2p/vP9pqf7Df8OuMxvucet4QXASmv4NnzdSDvb34/v7vdVQJY1bVH7vuiU+yHgTr/xWKAUiANuBX7pN6+4fVl8zzx4zhp+CrjfGr4EXxfdmcA1wLN+70/xW0+m33QDLPTb/hFgpDX+337fRzFwm9/3tMXvOyz3W18usNXuf6f6Cv6lRxgqlBbj6/gM67+Lu1jum8BLAMaYXcAhYKQ17xNjTL3xNWHU4usVFGArvqYtf6OAMmPMWmtddebUv8jB92CnV42v99FS4OMAeQ4Aw0XklyJyCdBVj7VzxPeksq34jgD8uw1v7wRwvV/Oi4D/as9kjDlhZT4X+Eh8XXv8A74ODTvLASr8xi/Ft2+a8HU8eGWnZqJA2/8m1vdhjHkfqLambwXmWUdFs40xtV18Xo+1LazcB40xe6zx3+Lbt+3a+2fbiu8hU+3fYYtY/TLh6yrctnNCqucGXF9SKjys5qK5wHgRMfj+ojci8n96uKoWv2Gv37iXEP37NcZUi8hE4GLgh8BCfOcPOohILPArfEccR0TkH/H91d05t+c0OQXYboyZ2c0y4OsDyn/9i4Fviq83UvA9x2AuvqOnnmwfY8we8T1qdgHwcxH5szHm4QCLNhtjPKfJ2c7/e+r8HbbnicX3uVQ/oUcYKlSuBX5njBlqjCk0xuQDB4HZQD2+Jop2f8FqyxaRkfg6ztvdi23uBnJEZLq1riTrZLG/z4BF1vmEHGBO55WIr+vvKGPMCnx/8bc/t9s/d/uPd6V1rubaIPJ9BPyv9kxWUd0NZInITGuaSwI/4GgncI61TDK+/Vhg7dtC4Ed0fQTX7q/4ih8iMh9Is4aHAI3GmJeAX3TxeTvbDRSKyDnW+E3A/5xm+52NBAI+811FJi0YKlQWA3/oNG2FNX0L4LFOst6L7y/1KKtpZxmwxHz1bIGgGd8jdxcBv7ROzH7EqX+VY2XaC+zA1+6+OsCqcoFPrSail4D7rekvAk9b01uAZ/H94H2Ar9v803kO3/mZLVa+71mZrwX+xZq2CfhGgPe+x1dNPlfh64rafx+9BVzWfuK5Cw8B80VkG3AdcAxfURgPfGl9rgeBn1vLPwO8337S258xphlfT73Lre/NCzx9uh3QyRzgTz18j7KR9larVD8hIn8AfmKM2dvL98cAHuPr4n8m8Gvje4qcLUTkM+AKY0z1aRdWEUHPYSjVf9yH7+R3rwoGvqa+10UkCmgFftBXwXpKRLKAf9Ni0b/oEYZSSqmg6DkMpZRSQdGCoZRSKihaMJRSSgVFC4ZSSqmgaMFQSikVFC0YSimlgvL/AX0oxGT2AlhBAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -576,7 +577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,7 +585,7 @@
     "molecule = driver.run()\n",
     "num_particles = molecule.num_alpha + molecule.num_beta\n",
     "qubitOp = FermionicOperator(h1=molecule.one_body_integrals, h2=molecule.two_body_integrals).mapping(map_type='parity')\n",
-    "qubitOp = qubitOp.two_qubit_reduced_operator(num_particles)"
+    "qubitOp = Z2Symmetries.two_qubit_reduction(qubitOp, num_particles)"
    ]
   },
   {
@@ -596,14 +597,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
     "IBMQ.load_account()\n",
     "provider = IBMQ.get_provider(hub='ibm-q')\n",
     "backend = Aer.get_backend(\"qasm_simulator\")\n",
-    "device = provider.get_backend(\"ibmqx4\")\n",
+    "device = provider.get_backend(\"ibmqx2\")\n",
     "coupling_map = device.configuration().coupling_map\n",
     "noise_model = noise.device.basic_device_noise_model(device.properties())\n",
     "quantum_instance = QuantumInstance(backend=backend, shots=1000, \n",
@@ -624,15 +625,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exact Result: -1.86712097834127\n",
-      "VQE Result: -1.8220854070067132\n"
+      "Exact Result: -1.8671209783412681\n",
+      "VQE Result: -1.8429114965754119\n"
      ]
     }
    ],
@@ -641,7 +642,7 @@
     "print(\"Exact Result:\", exact_solution['energy'])\n",
     "optimizer = SPSA(max_trials=100)\n",
     "var_form = RYRZ(qubitOp.num_qubits, depth=1, entanglement=\"linear\")\n",
-    "vqe = VQE(qubitOp, var_form, optimizer=optimizer, operator_mode=\"grouped_paulis\")\n",
+    "vqe = VQE(qubitOp, var_form, optimizer=optimizer)\n",
     "ret = vqe.run(quantum_instance)\n",
     "print(\"VQE Result:\", ret['energy'])"
    ]
@@ -691,7 +692,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description of Issue

Fixes #172 
Fixes #116 
Probably Fixes #115 

## What Changes Were Made?

- Remove ibmqx4 backend in favor of ibmqx2
- Removed deprecated option `operator_mode` from VQE calls ('matrix' and 'grouped_paulis')
- Replaced `qubitOp.two_qubit_reduced_operator` with `Z2Symmetries.two_qubit_reduction`
- Updated Imports to use correct paths of current Qiskit Version
- Replace deprecated `line_length` in favor of `fold` in `draw()`
- Re-Run whole notebook to update values and run counters

## How Was This Tested?

The results are pretty near to the ones before.

Though, someone familiar with the topic should take a look please :)