### PR TITLE
Fixed wrong statement about inverting noise matrix

### DIFF
--- a/content/ch-quantum-hardware/measurement-error-mitigation.ipynb
+++ b/content/ch-quantum-hardware/measurement-error-mitigation.ipynb
@@ -262,10 +262,6 @@
     "Unfortunately, this is the exact opposite of what we need. Instead of a way to transform ideal counts data into noisy data, we need a way to transform noisy data into ideal data. In linear algebra, we do this for a matrix $M$ by finding the inverse matrix $M^{-1}$,\n",
     "\n",
     "$$C_{ideal} = M^{-1} C_{noisy}.$$\n",
-    "\n",
-    "The trouble is, such an inverse does not always exist. To obtain an inverse, we need the colums of the original matrix to be orthogonal to each other. This is not the case for the matrix above. Indeed, it will not hold for any matrix describing measurement noise.\n",
-    "\n",
-    "One possible method is to use the so-called 'pseudo inverse'. In Python, this can be applied using one of the linear algebra tools from Scipy."
    ]
   },
   {
@@ -293,7 +289,7 @@
     "    [0.0096,0.0002,0.9814,0.0087],\n",
     "    [0.0001,0.0103,0.0090,0.9805]]\n",
     "\n",
-    "Minv = la.pinv(M)\n",
+    "Minv = la.inv(M)\n",
     "\n",
     "print(Minv)"
    ]

--- a/content/ch-quantum-hardware/measurement-error-mitigation.ipynb
+++ b/content/ch-quantum-hardware/measurement-error-mitigation.ipynb
@@ -261,7 +261,7 @@
     "\n",
     "Unfortunately, this is the exact opposite of what we need. Instead of a way to transform ideal counts data into noisy data, we need a way to transform noisy data into ideal data. In linear algebra, we do this for a matrix $M$ by finding the inverse matrix $M^{-1}$,\n",
     "\n",
-    "$$C_{ideal} = M^{-1} C_{noisy}.$$\n",
+     "$$C_{ideal} = M^{-1} C_{noisy}.$$\n"
    ]
   },
   {


### PR DESCRIPTION
The textbook claimed that "To obtain an inverse, we need the colums of the original matrix to be orthogonal to each other." This isn't true, you just need the determinant to be nonzero. Matrices with nonzero determinant are a set of measure zero, so you will never actually get one from any numerical procedure.

On the other hand, it IS true that when the determinant is very small, the inverse is very sensitive to noise. This isn't fixed by using the pseudoinverse, though. You just need to do careful error propagation.