### PR TITLE
Fixed complex to float warnings in vqls

### DIFF
--- a/content/ch-paper-implementations/vqls.ipynb
+++ b/content/ch-paper-implementations/vqls.ipynb
@@ -598,13 +598,13 @@
     "            job = execute(circ, backend)\n",
     "\n",
     "            result = job.result()\n",
-    "            outputstate = result.get_statevector(circ, decimals=100)\n",
+    "            outputstate = np.real(result.get_statevector(circ, decimals=100))\n",
     "            o = outputstate\n",
     "\n",
     "            m_sum = 0\n",
     "            for l in range (0, len(o)):\n",
     "                if (l%2 == 1):\n",
-    "                    n = float(o[l])**2\n",
+    "                    n = o[l]**2\n",
     "                    m_sum+=n\n",
     "\n",
     "            overall_sum_1+=multiply*(1-(2*m_sum))\n",
@@ -633,13 +633,13 @@
     "                job = execute(circ, backend)\n",
     "\n",
     "                result = job.result()\n",
-    "                outputstate = result.get_statevector(circ, decimals=100)\n",
+    "                outputstate = np.real(result.get_statevector(circ, decimals=100))\n",
     "                o = outputstate\n",
     "\n",
     "                m_sum = 0\n",
     "                for l in range (0, len(o)):\n",
     "                    if (l%2 == 1):\n",
-    "                        n = float(o[l])**2\n",
+    "                        n = o[l]**2\n",
     "                        m_sum+=n\n",
     "                mult = mult*(1-(2*m_sum))\n",
     "\n",
@@ -670,1423 +670,223 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/anaconda3/lib/python3.7/site-packages/ipykernel_launcher.py:35: ComplexWarning: Casting complex values to real discards the imaginary part\n",
-      "/usr/local/anaconda3/lib/python3.7/site-packages/ipykernel_launcher.py:70: ComplexWarning: Casting complex values to real discards the imaginary part\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.7431519120065692\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.6517072836492874\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.7686394139639541\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.6288547153007085\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.5535558081696941\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.5093791924844618\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.48986958424759963\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.6062382993878102\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.5735345947611614\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.5991395924932272\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.5606977115473802\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.5301298604771039\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.6863644264209006\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.500219948214973\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.5179939766794508\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.47990524237755083\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.5104946457641515\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.4781797759533113\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.46818484021331486\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.44577803177531483\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.4347607204531386\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.435044520576755\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.44804130808816434\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.43980652028215894\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.42947534589437397\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.4407884529761009\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.43026675293547845\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.4321131261697083\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.44424592143852437\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.42140341826693395\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.4163399838418421\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.4152838756247722\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.41683502471854106\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.39500701748807276\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.376055028073219\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.35669766185735174\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.33989464412105697\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3475915719429997\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3520638333549443\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3516644695673603\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.37030302140080273\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3251904919262958\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.32730312378284887\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3139831937195785\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3206879407528469\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3021917416447806\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3500772391925613\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3207098620425859\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.27653626486756766\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2330785180385314\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2525168978764344\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.24463461996387015\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2030751479855165\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2792777548411941\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.20029488860984623\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.4185014472966907\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.23906848444238027\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.23804695305897716\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.22978967784311566\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2156503981784803\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.20348023687776462\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2002435799973592\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.20160888245501585\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.20069522876974866\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.21856088831856213\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.20077995796479486\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.19873950725246725\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.19074567998348735\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.19186917612943188\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.19337864220115963\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.18987174322272893\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.18880934987753584\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.18730015897491525\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1858005363027343\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.18486389353320198\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.19330275856032608\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.18453724358749002\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1768410218059464\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.17535896016389008\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.17278150138675452\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1721715254319488\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.17050742795238572\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16518816517217194\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16426427883976136\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16558348391939848\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.18175470150028594\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16081997040812146\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16377342501139414\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16134811106650326\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16314674930389916\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16260961201165525\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16747655457044497\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16087163842235686\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1583598027979134\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.15915702228156214\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16181019867217028\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16150922344374163\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1564199382540138\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1533807812099356\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.15379922197537066\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.15445238656470028\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.15369254264897758\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.15372813136898322\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.15145673846473529\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1553493257690024\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.15050235998420247\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1518458768458899\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.15061210531943836\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14690802047737206\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14925629956858433\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14787368294892544\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14585451373586678\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.145705995092281\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14608920468185116\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14497156286971435\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14474025049657047\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14600352315772314\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14557138570645767\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14918778197785287\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13976697739712063\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14005183579920133\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1405310772603131\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13744928349708385\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1372444190511778\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13595509291999197\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1357845041067831\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13503394567350202\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1400556792846469\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13542077478105685\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13172701165952871\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1324298835901645\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13329058497660873\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13052685135756714\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13190425809792072\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1271409120072161\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12613380536876262\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12953119409928127\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12621339331947878\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12551777224976757\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1272906013016084\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12489219214765157\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12512728510197235\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12278533873372\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12288439397260997\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12510295310388642\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11985361442862286\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11799981565812367\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11822261244055876\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11663840455730012\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11473345279583402\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11376543995625976\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11481343902359586\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11242725821296595\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11066332769683551\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10872974475323505\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10805277822079007\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10783827054441475\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10877405574826227\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10710276438986399\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11126691799482702\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10893773471055945\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10824399800988582\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10644009592909132\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10529060169658366\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1063685042438145\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10647988058201963\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10345513306916365\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10355584413034447\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10386243779184712\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10237894801758818\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10075533644664303\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0992882373172348\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09831283825772075\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09796380237953506\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09806369779983093\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09738606116567394\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0960346399064429\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0960967818463121\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09615226100517937\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09495451538967892\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09411720630008924\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09338312576929664\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0928840385945674\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0932682548604361\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09285044430512046\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09214441495775405\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09178124040491609\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0910400361250876\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09145349906150746\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09039371245741823\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08943630000916702\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09013206037737498\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08957573088463\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08877023828792485\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08738973735001898\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08736085463042653\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08769407188602507\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08672907934932961\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08625629697010229\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.08593782593599897\n",
-      "     fun: 0.08593782593599897\n",
+      "0.9918122817745821\n",
+      "0.9165772444418112\n",
+      "0.9451082307384663\n",
+      "0.5868733250896592\n",
+      "0.4302619270249567\n",
+      "0.45598651598739137\n",
+      "0.8994816130322991\n",
+      "0.4080696647909037\n",
+      "0.49282340661736845\n",
+      "0.867102398163604\n",
+      "0.6956212894149755\n",
+      "0.3778233167789482\n",
+      "0.41975514432352734\n",
+      "0.35221586187565035\n",
+      "0.33376601920443916\n",
+      "0.5141988884968168\n",
+      "0.33856570095106175\n",
+      "0.47673154926922945\n",
+      "0.358541819707732\n",
+      "0.4862500892961612\n",
+      "0.35497183221088946\n",
+      "0.5564883346025258\n",
+      "0.3218966034126638\n",
+      "0.32812513733672377\n",
+      "0.3713276834182113\n",
+      "0.33238056251536663\n",
+      "0.3663266997623691\n",
+      "0.30732132504312204\n",
+      "0.35919632608676066\n",
+      "0.33278311474756883\n",
+      "0.3466153951077714\n",
+      "0.3116110702708369\n",
+      "0.2996601754190389\n",
+      "0.27818391462773473\n",
+      "0.28911874310837493\n",
+      "0.2721436020908149\n",
+      "0.34074214571803074\n",
+      "0.27232172105955277\n",
+      "0.27326645728495613\n",
+      "0.24838597577630617\n",
+      "0.26529479921220733\n",
+      "0.265161247268774\n",
+      "0.2359332766834491\n",
+      "0.2531398051824344\n",
+      "0.23071961605660385\n",
+      "0.2439886344161406\n",
+      "0.22698460720911906\n",
+      "0.25684055531551775\n",
+      "0.22875251321677248\n",
+      "0.22795049872095519\n",
+      "0.24539562404567217\n",
+      "0.23036314430499039\n",
+      "0.22529759695808516\n",
+      "0.22340008950012624\n",
+      "0.23193536221334798\n",
+      "0.2251811696077659\n",
+      "0.2158713780553012\n",
+      "0.22196771485897682\n",
+      "0.21970093360373655\n",
+      "0.21891411938728478\n",
+      "0.21658730785057134\n",
+      "0.2144287938544832\n",
+      "0.21989826170510673\n",
+      "0.2141914301898592\n",
+      "0.20528607684202504\n",
+      "0.2088418539329956\n",
+      "0.20459778971615838\n",
+      "0.19987803706121166\n",
+      "0.19893761456484016\n",
+      "0.19616806764284012\n",
+      "0.1930330113456542\n",
+      "0.1943243033562907\n",
+      "0.19080398983869673\n",
+      "0.1906922014667165\n",
+      "0.19462879693756052\n",
+      "0.1859133448034428\n",
+      "0.18351812137483592\n",
+      "0.18074231783494554\n",
+      "0.1810830721107627\n",
+      "0.18966402012749628\n",
+      "0.18342289558983071\n",
+      "0.1812614238353928\n",
+      "0.17790896996280603\n",
+      "0.17505698805256087\n",
+      "0.1886124114165414\n",
+      "0.17952255153417818\n",
+      "0.17321124745406546\n",
+      "0.172999137743724\n",
+      "0.17180809837448952\n",
+      "0.16774778950450497\n",
+      "0.16652296695029356\n",
+      "0.16653040433083954\n",
+      "0.16512579449126596\n",
+      "0.16563154200741126\n",
+      "0.16780509827127987\n",
+      "0.16172811489283734\n",
+      "0.16048388588813667\n",
+      "0.16096569349447076\n",
+      "0.1588119567334445\n",
+      "0.15852622533563754\n",
+      "0.1575363102051044\n",
+      "0.15429052618440142\n",
+      "0.15254004107907204\n",
+      "0.1530324425986468\n",
+      "0.15439963210050622\n",
+      "0.14874621449118108\n",
+      "0.14624484321667963\n",
+      "0.14801185134479933\n",
+      "0.1462357515064424\n",
+      "0.14415859560862299\n",
+      "0.14316240214308895\n",
+      "0.14310527234655002\n",
+      "0.1419533183646663\n",
+      "0.13845502852170655\n",
+      "0.13646795003464474\n",
+      "0.13408382790570295\n",
+      "0.13205199174171633\n",
+      "0.1278456932203923\n",
+      "0.12514633875869963\n",
+      "0.12238813933937054\n",
+      "0.12027578909892189\n",
+      "0.11737039289567508\n",
+      "0.11308687822341379\n",
+      "0.11012421598177435\n",
+      "0.10744785828352832\n",
+      "0.1040228616663007\n",
+      "0.10103072464108798\n",
+      "0.09779053536336924\n",
+      "0.09522186989435266\n",
+      "0.09422030386647007\n",
+      "0.09177968671091419\n",
+      "0.09303903590464513\n",
+      "0.0917898308664612\n",
+      "0.08841085993415176\n",
+      "0.08684124499912871\n",
+      "0.08722693405527926\n",
+      "0.08620255242602781\n",
+      "0.08427263447135569\n",
+      "0.08572650301324503\n",
+      "0.08562487735155344\n",
+      "0.0820832716205585\n",
+      "0.07999057007939214\n",
+      "0.07844811859147338\n",
+      "0.07725749720991781\n",
+      "0.07662555381394487\n",
+      "0.07740159369911492\n",
+      "0.07463894642398827\n",
+      "0.07732528822812612\n",
+      "0.07528938119250983\n",
+      "0.07152114447013214\n",
+      "0.07148399641827896\n",
+      "0.07138495406498424\n",
+      "0.07065924502078269\n",
+      "0.07036560946851111\n",
+      "0.07186845982528156\n",
+      "0.07093184183488899\n",
+      "0.06800865879118723\n",
+      "0.06916651116569061\n",
+      "0.06683178579603777\n",
+      "0.06577366430276821\n",
+      "0.06428841453421053\n",
+      "0.06314754529071498\n",
+      "0.06229270415239074\n",
+      "0.0661798607249291\n",
+      "0.06196080653472824\n",
+      "0.06062263933639189\n",
+      "0.05984196961302024\n",
+      "0.05888427919549932\n",
+      "0.056745217206204956\n",
+      "0.061352299933729704\n",
+      "0.05725200623279447\n",
+      "0.054930307152590396\n",
+      "0.052030341056147233\n",
+      "0.049220950134593044\n",
+      "0.046572186507744195\n",
+      "0.044942448921497125\n",
+      "0.043069517962818105\n",
+      "0.04242374041859287\n",
+      "0.04217529084652616\n",
+      "0.04083551634837068\n",
+      "0.04049136038654222\n",
+      "0.040796367307559644\n",
+      "0.03681848640132923\n",
+      "0.03891053363214958\n",
+      "0.0364884334383605\n",
+      "0.036854043816544224\n",
+      "0.03695449592271027\n",
+      "0.03827618890843165\n",
+      "0.03652636227635764\n",
+      "0.03822208318337472\n",
+      "0.03796323236643273\n",
+      "0.03538506816204112\n",
+      "0.037625087082405195\n",
+      "0.03636379971022563\n",
+      "0.03453021449182958\n",
+      "0.032475811352658535\n",
+      "0.03362151632017596\n",
+      "0.03223137423023548\n",
+      "0.03372474689869098\n",
+      "0.03273673575407443\n",
+      "     fun: 0.03223137423023548\n",
       "   maxcv: 0.0\n",
       " message: 'Maximum number of function evaluations has been exceeded.'\n",
       "    nfev: 200\n",
       "  status: 2\n",
       " success: False\n",
-      "       x: array([3.05946583, 2.56872721, 0.66111666, 3.13239331, 2.65269555,\n",
-      "       1.61153277, 0.9783244 , 0.93394305, 1.9890077 ])\n",
-      "(0.9140621740591953-0j)\n"
+      "       x: array([3.15896973, 1.11155641, 1.83786526, 2.53221315, 1.47145485,\n",
+      "       1.91849939, 2.61169694, 0.96122794, 2.87661968])\n",
+      "(0.96776862579723-0j)\n"
      ]
     }
    ],
@@ -2122,7 +922,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, our cost function has acheived a fairly low value of $0.005907904334877201$, and when we calculate our classical cost function, we get $0.9940920956678407$, which agrees perfectly with what we measured, the vectors $|\\psi\\rangle_o$ and $|b\\rangle$ are very similar!\n",
+    "As you can see, our cost function has acheived a fairly low value of `0.03273673575407443`, and when we calculate our classical cost function, we get `0.96776862579723`, which agrees perfectly with what we measured, the vectors $|\\psi\\rangle_o$ and $|b\\rangle$ are very similar!\n",
     "\n",
     "Let's do another test! This time, we will keep $|b\\rangle$ the same, but we will have:\n",
     "\n",
@@ -2137,1424 +937,222 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/anaconda3/lib/python3.7/site-packages/ipykernel_launcher.py:35: ComplexWarning: Casting complex values to real discards the imaginary part\n",
-      "/usr/local/anaconda3/lib/python3.7/site-packages/ipykernel_launcher.py:70: ComplexWarning: Casting complex values to real discards the imaginary part\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.9173574611133545\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.6981743645958717\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.7888579987120473\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.7561934395063615\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.5776969846052474\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.448433530669503\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.33520976298633787\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3522198674509871\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.31990339019093383\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.296153542266292\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.996242565284017\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.7088729418499999\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3571583440526943\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.29573583676759674\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.5168005439118196\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.4640544005484657\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.4115292009956585\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.27241290925039685\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2606786772921087\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2418103780335099\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.26692159867248666\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.374845885525091\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3451767154548915\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.23415342468013123\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2828956332689947\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.24299484780233582\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.19685194565851627\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1675597831812583\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2513514791335245\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1756762551244755\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2637422486475328\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.21245343989465548\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.19913872998801885\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1819594850743289\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.19486616935145218\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16767723804748202\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16835824522428045\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.16890358814115902\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.15736943414861848\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.14574180529180136\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1312526508477565\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12980530854338868\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13281728011905125\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11500042055859294\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10610592655717432\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0955446920828773\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08327807011916333\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.07339006897945721\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.05779109969762353\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.06080039917717206\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0496166206941665\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.03627551874177537\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0579996922009558\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.037523480031675494\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.05086281219430899\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.03874089152047855\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.03053353549801585\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.029688215480617064\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.03681482313484952\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.04474845677492212\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.01761365224389344\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.022561155609123085\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.015119882152114017\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.012968813811784496\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.01378212794705469\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.016555055740794966\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.008769975244203643\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.008851944091827102\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.014255193913773945\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.008478864138678044\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.006709447397487467\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.006937480476158275\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.014202735182617388\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.007420167155868573\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0071262137260933445\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.003990431147646634\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.01033559105639148\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.004012898589974667\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0027885947649373133\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0031599047658671386\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0013776636376193752\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0034111897038677785\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0013898241038579062\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.002747171322767472\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.001051863055287705\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.002286221914666986\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0009855448786123544\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0034269161615083643\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.005476587944727829\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0009952622179648651\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.001109330813492737\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0010236421698032183\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.001194944984860391\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0014013914333184108\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.000981015762755666\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0009718095730139042\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.000913911323482175\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.001146750154641274\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0010102333221566617\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0006366776515626116\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0006449925588432048\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0006558846207260771\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0005314781094236665\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0006848470567005771\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0005323984326808251\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0005179189467798828\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0004519503056119589\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00048654482469256966\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0005061208465082512\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0005053069860995185\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0004319913001327169\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0004530204698618423\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0004612329471983534\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.000439481075121817\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00042815482245128766\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0004391397149245968\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0004311854525256287\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00037243171685574783\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00034229602160551487\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0003723536508024594\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00033406878508335236\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0002981152908011486\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00027184350721587425\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0002769228000429891\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0002665691284505778\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0002477589172047434\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0002435118665012892\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0002514175452865697\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00031010560849720203\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00023798247407680329\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0002681284673118345\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00021468765745458196\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00020202642191902154\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00021241975822328119\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0002506774789965416\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00023490200767073421\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00019459718380909763\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0001750088907798153\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0001657411504583095\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00016601269015847908\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00016268862918311644\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00016458897936311168\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00014861101739915838\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00014213632848791846\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00012943976975665628\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00014583664126055496\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00013000449648492562\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00013016805155641187\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00013101780418522946\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00013955536074450325\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00012768695829401544\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00012655355412938274\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00012876527474969812\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0001282044990208453\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00012922886257538124\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00012409644573174727\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00012317887945589856\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0001239060485419552\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0001281613992458741\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00011866902473600671\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00011737667441757971\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00011668346979054611\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00010912086098469054\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00010709614629711428\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00010607601713674697\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00010744621455105463\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00010553953262426585\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00010090054083966571\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00010065732333863764\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00010284262616555573\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9.984366716520032e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0001002204304202392\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9.369490665900315e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8.989560227545823e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9.148907931832984e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8.906484599602305e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "9.444325207841331e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8.931801658873528e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8.402514020799945e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8.284236944011703e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8.379591251661545e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8.291421023232104e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8.302467885246134e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8.175032751744915e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7.731167291180618e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7.390522086336837e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7.337042704480545e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7.269151699329512e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7.462092614585192e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7.24175316649811e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6.926855304512092e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6.799265123447196e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7.0009008268479e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "7.292021396121395e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6.886344078615991e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6.706101875453285e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6.16819801001478e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6.13282153120176e-05\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6.355147859749e-05\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6.315291684899638e-05\n",
-      "     fun: 6.13282153120176e-05\n",
+      "0.8313586791037413\n",
+      "0.9339310280455083\n",
+      "0.7965686063173347\n",
+      "0.7898479288889872\n",
+      "0.6332954097733461\n",
+      "0.6230249069616209\n",
+      "0.8471077778629463\n",
+      "0.8650816487479014\n",
+      "0.5160330058082485\n",
+      "0.7436668591417779\n",
+      "0.38751783955332997\n",
+      "0.6577791073925889\n",
+      "0.4305138862719746\n",
+      "0.30512222581636506\n",
+      "0.3958533813095887\n",
+      "0.5461818556602287\n",
+      "0.4026113571844494\n",
+      "0.30212478885853866\n",
+      "0.31868437554216755\n",
+      "0.24191709755511637\n",
+      "0.248192048217738\n",
+      "0.37416556907392307\n",
+      "0.31415351877318143\n",
+      "0.3739645023817735\n",
+      "0.32906605896478025\n",
+      "0.276723399111514\n",
+      "0.17508997347878963\n",
+      "0.21955435456675565\n",
+      "0.19890829027008017\n",
+      "0.17487356732255577\n",
+      "0.26096518828953696\n",
+      "0.21692502569281003\n",
+      "0.21212920238485133\n",
+      "0.16672035940187813\n",
+      "0.2001223428181116\n",
+      "0.1450914367650773\n",
+      "0.19729939249189055\n",
+      "0.16240928510222696\n",
+      "0.14977214614634027\n",
+      "0.16274243618244555\n",
+      "0.1351785512280027\n",
+      "0.1424220554189396\n",
+      "0.14090313127326692\n",
+      "0.12885923752993078\n",
+      "0.13885949550807009\n",
+      "0.12698451294156943\n",
+      "0.12911467929170828\n",
+      "0.12230056540942658\n",
+      "0.13065783768177675\n",
+      "0.12251947052683565\n",
+      "0.11362302539164904\n",
+      "0.1256649281146648\n",
+      "0.1131052682912651\n",
+      "0.11226520466459289\n",
+      "0.10891818655756969\n",
+      "0.11881518833216109\n",
+      "0.11592406762147789\n",
+      "0.10162529433546319\n",
+      "0.11086053345178426\n",
+      "0.10182293898658878\n",
+      "0.11596762448450548\n",
+      "0.10034095827416467\n",
+      "0.10625843048873629\n",
+      "0.0934330650476336\n",
+      "0.0963907259039537\n",
+      "0.09317186122798182\n",
+      "0.09555519587046857\n",
+      "0.09562664135181487\n",
+      "0.08989730722865708\n",
+      "0.08775113039053617\n",
+      "0.08118309630921827\n",
+      "0.07529699316027694\n",
+      "0.07434003549019352\n",
+      "0.07596020806682513\n",
+      "0.06952394039146692\n",
+      "0.06581446749916087\n",
+      "0.06815449654234773\n",
+      "0.06629397429952066\n",
+      "0.07561046146452166\n",
+      "0.06832717456123638\n",
+      "0.06371362851863838\n",
+      "0.0690644663139014\n",
+      "0.06411259619274357\n",
+      "0.06497086620842463\n",
+      "0.06383230111715155\n",
+      "0.06706074945048324\n",
+      "0.062093831533091226\n",
+      "0.06520011270025472\n",
+      "0.06086033170754557\n",
+      "0.060976010840217865\n",
+      "0.06172203399923526\n",
+      "0.05832567353568208\n",
+      "0.057311336835422\n",
+      "0.0576679143937594\n",
+      "0.057137924915087845\n",
+      "0.05648903613504319\n",
+      "0.0561293565238673\n",
+      "0.0537075462636144\n",
+      "0.0512865898104955\n",
+      "0.04921351427632514\n",
+      "0.049550704718404504\n",
+      "0.048910510972885124\n",
+      "0.04800376755276148\n",
+      "0.047475937632144305\n",
+      "0.04671573663031903\n",
+      "0.047486065255693655\n",
+      "0.04827612644289747\n",
+      "0.04653669657199744\n",
+      "0.04968516522758104\n",
+      "0.04529391707882746\n",
+      "0.04585401214896001\n",
+      "0.047560790115114715\n",
+      "0.04163685605599554\n",
+      "0.04018431243106979\n",
+      "0.03751392213694971\n",
+      "0.036857119053267384\n",
+      "0.037626147297615264\n",
+      "0.039397657106090334\n",
+      "0.03690677817774435\n",
+      "0.03416296614006176\n",
+      "0.037622833188078686\n",
+      "0.03419019450077898\n",
+      "0.033971228701244915\n",
+      "0.03514937677511243\n",
+      "0.03500514691065004\n",
+      "0.03159710572430996\n",
+      "0.02740833883678251\n",
+      "0.024728033782769443\n",
+      "0.025645089551535882\n",
+      "0.025493134289651387\n",
+      "0.02212348817685683\n",
+      "0.023116127048347757\n",
+      "0.021055271758286143\n",
+      "0.019165954809235775\n",
+      "0.019037574329216156\n",
+      "0.018912304784477585\n",
+      "0.01878457260969124\n",
+      "0.018566877754853772\n",
+      "0.022581844478186786\n",
+      "0.016158252631757297\n",
+      "0.01678419199892134\n",
+      "0.014513355016084528\n",
+      "0.012498844215309668\n",
+      "0.014667088357727454\n",
+      "0.01165447652368723\n",
+      "0.01136131126860307\n",
+      "0.012315305942062649\n",
+      "0.009775043129676475\n",
+      "0.013595364970228063\n",
+      "0.00788064005453526\n",
+      "0.006329608736745818\n",
+      "0.0070654170438552155\n",
+      "0.006272494356060365\n",
+      "0.00559434449029661\n",
+      "0.004211544867244399\n",
+      "0.006312717960868852\n",
+      "0.004895788720288841\n",
+      "0.0027061547942631714\n",
+      "0.003869742747936278\n",
+      "0.0025375213767010463\n",
+      "0.003384093207724592\n",
+      "0.0033206161407141055\n",
+      "0.0016268586076800817\n",
+      "0.0052658227876406505\n",
+      "0.002152295160275486\n",
+      "0.002071954465751147\n",
+      "0.001984304073993637\n",
+      "0.0017795804300215767\n",
+      "0.0024291831944041054\n",
+      "0.001788773533289989\n",
+      "0.0009301516398538823\n",
+      "0.0011555477083410315\n",
+      "0.0011098582702181448\n",
+      "0.0016610055909076493\n",
+      "0.0011362766334523933\n",
+      "0.0009635267062650943\n",
+      "0.0009573928622628181\n",
+      "0.0008677193748665157\n",
+      "0.0007123510912490083\n",
+      "0.0007285313432860985\n",
+      "0.0004425110152737055\n",
+      "0.0003445336654389619\n",
+      "0.0005310444027962768\n",
+      "0.0003729465786603825\n",
+      "0.00021227609865914765\n",
+      "0.0003008412497902402\n",
+      "0.00022077440081391675\n",
+      "0.00028255850226432955\n",
+      "0.0002315127105823045\n",
+      "0.0005356099868689679\n",
+      "0.00033067757988913815\n",
+      "0.00018805014605838277\n",
+      "0.00020220372819446109\n",
+      "0.000184175296607747\n",
+      "0.0001772643644802896\n",
+      "0.00022029221972308388\n",
+      "0.0001610964002867199\n",
+      "0.00014365810056216066\n",
+      "0.00019546769079681336\n",
+      "0.00014718223342624626\n",
+      "     fun: 0.00014365810056216066\n",
       "   maxcv: 0.0\n",
       " message: 'Maximum number of function evaluations has been exceeded.'\n",
       "    nfev: 200\n",
       "  status: 2\n",
       " success: False\n",
-      "       x: array([2.45720129, 3.132281  , 2.98704735, 3.48143203, 2.69747448,\n",
-      "       3.30564216, 1.94439123, 3.17643158, 2.48230812])\n",
-      "(0.99993867178467-0j)\n"
+      "       x: array([ 2.11901731,  3.15340216,  0.31022214,  4.20152471,  3.57558027,\n",
+      "        0.29595732, -0.43666737,  2.34545006,  3.02467777])\n",
+      "(0.9998563418983931-0j)\n"
      ]
     }
    ],
@@ -3592,7 +1190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again, very low error, $0.0001115758871370609$, and the classical cost function agrees, being $0.9998884241081756$! Great, so it works!\n",
+    "Again, very low error, `0.00014718223342624626`, and the classical cost function agrees, being `0.9998563418983931`! Great, so it works!\n",
     "\n",
     "Now, we have found that this algorithm works **in theory**. I tried to run some simulations with a circuit that samples the circuit instead of calculating the probabilities numerically. Now, let's try to **sample** the quantum circuit, as a real quantum computer would do! For some reason, this simulation would only converge somewhat well for a ridiculously high number of \"shots\" (runs of the circuit, in order to calculate the probability distribution of outcomes). I think that this is mostly to do with limitations in the classical optimizer (COBYLA), due to the noisy nature of sampling a quantum circuit (a measurement with the same parameters won't always yield the same outcome). Luckily, there are other optimizers that are built for noisy functions, such as SPSA, but we won't be looking into that in this tutorial. Let's try our sampling for our second value of $A$, with the same matrix $U$:"
    ]
@@ -3694,751 +1292,124 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.7535431757521419\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.773418763532361\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.583207224178788\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.8567045877423063\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.6041339716579768\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.7552822924854041\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3855531447963554\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.5780823858058172\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.6811130720586089\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3507950352399567\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.45979242739650683\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3698112610689549\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.41833407781784815\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2876234372110922\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.31215823532841425\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3101752820732684\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.28131206605034365\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.32047815523308143\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3565927094423845\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2299026660188298\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.3268174612398762\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.23558393625006124\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.19519716405516663\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2031798665531337\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.35587593815461815\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.2014088619474902\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.21539063317893892\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.183225688318575\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.17642756705303586\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1535596976697704\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09395936556675344\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13650441182645867\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12285645419782543\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.13942014127725688\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10366103358409084\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12918506392739437\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1100396260561175\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.12721489177359402\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11751410639302673\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1032137046926711\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1143794402143753\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09032527703259297\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10997426722314918\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10282267639257281\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0789683183514186\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09068525134009742\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.06863519817499553\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09070523211626469\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08156707857279444\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08499049677290116\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0973773897032828\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08228846476330876\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0971062324712677\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0686129731971915\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08691282167923942\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10120985626299805\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10555684895368334\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08500353534539484\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.07908237224158221\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.07553595153699999\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11961424395056719\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09727646640667842\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08844136969894689\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09495851407144507\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08913440232867531\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08302587903334557\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.07499670970355476\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10495779097871494\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08130617073505142\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08560361874637235\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08401359819435772\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09998683421334598\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09255749776912092\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10380466245491415\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08466553750735428\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.06413920008132223\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08162578385838504\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08687776289349791\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10333554822387647\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10602463002956786\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.07820954301406036\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08996161528399738\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.06730049635628566\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.07749076346762196\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09338097317995708\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08084520521151506\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08170400463057603\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08700652080881544\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0689421140219193\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08239341478925633\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.07672764073000227\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10898624967492587\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08423946052689835\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0951290231692048\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10383709616679881\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.10146986859728102\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0835487216273274\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09220466075946487\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.09582173540903327\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08432323830083299\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.06574887480955338\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0916891395437065\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.07554481026630855\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08828303135845605\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.07514072076578993\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.08434751024553067\n",
-      "     fun: 0.08434751024553067\n",
+      "0.8875843628866712\n",
+      "0.8589430907930592\n",
+      "0.9959911969469649\n",
+      "0.8163966862494658\n",
+      "0.7666251615975626\n",
+      "0.600596484637659\n",
+      "0.6082333614127609\n",
+      "0.640220553191939\n",
+      "0.4574662870295416\n",
+      "0.43832801729141246\n",
+      "0.5524189383739082\n",
+      "0.4038735102183886\n",
+      "0.444204256834531\n",
+      "0.42581251521835917\n",
+      "0.35495552369860117\n",
+      "0.2912019809739722\n",
+      "0.3028871303409435\n",
+      "0.3249995021516785\n",
+      "0.32382415600365777\n",
+      "0.35082574619211593\n",
+      "0.30516030398295546\n",
+      "0.23927272563432034\n",
+      "0.18611809671787782\n",
+      "0.19997768140812533\n",
+      "0.2432247846127732\n",
+      "0.20144351213454015\n",
+      "0.25979036535644384\n",
+      "0.20232762484941702\n",
+      "0.1802035747406736\n",
+      "0.21660490218304418\n",
+      "0.1760384769450105\n",
+      "0.21209205461792568\n",
+      "0.15607080961995412\n",
+      "0.15745972075726078\n",
+      "0.1489664140453496\n",
+      "0.14716794730293103\n",
+      "0.1366984670142174\n",
+      "0.1467855710309517\n",
+      "0.14734446218384933\n",
+      "0.13462822644491734\n",
+      "0.1269013375971051\n",
+      "0.13098460658313116\n",
+      "0.13841667959231574\n",
+      "0.136607009417945\n",
+      "0.12299598544489132\n",
+      "0.1202175906035502\n",
+      "0.11956672973115867\n",
+      "0.12695383880654199\n",
+      "0.123830430265643\n",
+      "0.10613867086418349\n",
+      "0.1271064627689663\n",
+      "0.12484281356165416\n",
+      "0.12620436712280103\n",
+      "0.13128516331849271\n",
+      "0.12234725166811011\n",
+      "0.11470522097497271\n",
+      "0.11695369469384909\n",
+      "0.11497147247400608\n",
+      "0.11455041752053441\n",
+      "0.12003873065804238\n",
+      "0.11039293313063947\n",
+      "0.1110184347522617\n",
+      "0.12246278842928182\n",
+      "0.11490727703296666\n",
+      "0.11061442952019196\n",
+      "0.11667107921043762\n",
+      "0.11648361353287673\n",
+      "0.1180573075696355\n",
+      "0.11648150516455613\n",
+      "0.11262386221965848\n",
+      "0.10610742072185986\n",
+      "0.12474264301662508\n",
+      "0.11154805191930706\n",
+      "0.11626195237417503\n",
+      "0.11308517385915384\n",
+      "0.1270193198671512\n",
+      "0.12285258848641689\n",
+      "0.12097194697177394\n",
+      "0.10825782295570319\n",
+      "0.11134113733648698\n",
+      "0.11437065339147845\n",
+      "0.11474569326381046\n",
+      "0.12307949073879754\n",
+      "0.11395825579494046\n",
+      "0.10761965037613563\n",
+      "0.1271690012348059\n",
+      "0.11382772983212941\n",
+      "0.1226237671757785\n",
+      "0.13284056028751057\n",
+      "0.12484502816550147\n",
+      "0.11392738230283994\n",
+      "0.11864958200978115\n",
+      "0.11166055214222448\n",
+      "0.11597649810322086\n",
+      "0.12113266241884757\n",
+      "0.11487536083847538\n",
+      "0.11128651879332718\n",
+      "0.1147922554428692\n",
+      "0.1301548301465748\n",
+      "0.11103375994378784\n",
+      "0.12521460048119637\n",
+      "0.11568257701126372\n",
+      "0.11550395402033808\n",
+      "0.11123470462193796\n",
+      "0.11612967999804791\n",
+      "0.1165537740470809\n",
+      "0.12306293457758832\n",
+      "0.1065800552162155\n",
+      "0.11477206421983566\n",
+      "     fun: 0.11477206421983566\n",
       "   maxcv: 0.0\n",
       " message: 'Optimization terminated successfully.'\n",
-      "    nfev: 106\n",
+      "    nfev: 109\n",
       "  status: 1\n",
       " success: True\n",
-      "       x: array([3.08407051, 1.99044302, 2.49632557, 2.75687155, 2.14624299,\n",
-      "       2.51774189, 1.91194205, 2.34707052, 2.29866668])\n",
-      "(0.9098337877858138-0j)\n"
+      "       x: array([3.81404295, 2.95209963, 3.37065287, 1.02346093, 3.11884837,\n",
+      "       3.22315293, 2.71801829, 2.07738792, 1.9981629 ])\n",
+      "(0.88307796575789-0j)\n"
      ]
     }
    ],
@@ -4476,7 +1447,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So as you can see, not amazing, our solution is still off by a fairly significant margin ($3.677\\%$ error isn't awful, but ideally, we want it to be **much** closer to 0). Again, I think this is due to the optimizer itself, not the actual quantum circuit. I will be making an update to this Notebook once I fugre out how to correct this problem (likely with the intoruction of a noisy optimizer, as I previously mentioned).\n",
+    "So as you can see, not amazing, our solution is still off by a fairly significant margin ($3.677\\%$ error isn't awful, but ideally, we want it to be **much** closer to 0). Again, I think this is due to the optimizer itself, not the actual quantum circuit. I will be making an update to this Notebook once I figure out how to correct this problem (likely with the introduction of a noisy optimizer, as I previously mentioned).\n",
     "\n",
     "**Acknowledgements**\n",
     "\n",


### PR DESCRIPTION
## Description of Issue (if Applicable)
VQLS chapter was giving a warning
Fixes #117

## What Changes Were Made?
float() --> np.real()
## How Was This Tested?
output of statevector (which was being cast to float) had imaginary part of 0, so I believe discarding the imaginary part is intentional and used np.real() to suppress the warnings.
