### PR TITLE
fixed typos in qaoa.ipynb

### DIFF
--- a/content/ch-applications/qaoa.ipynb
+++ b/content/ch-applications/qaoa.ipynb
@@ -58,11 +58,11 @@
     "\n",
     "$$ Z_i = \\left(\\begin{array}{cc} 1 & 0 \\\\ 0 & -1 \\end{array}\\right). $$\n",
     "\n",
-    "This means that the spin - Hamiltonian encoding the classical cost funtion is written as a $|Q|$ - local quantum spin Hamiltonain only involving Pauli $Z$- operators. \n",
+    "This means that the spin - Hamiltonian encoding the classical cost funtion is written as a $|Q|$ - local quantum spin Hamiltonian only involving Pauli $Z$- operators. \n",
     "\n",
     "$$ H = \\sum_{(Q,\\overline{Q}) \\subset [n]} w_{(Q,\\overline{Q})} \\; \\frac{1}{2^{|Q| + |\\overline{Q}|}}\\prod_{i\\in Q} \\left(1 - Z_i\\right) \\; \\prod_{j\\in \\overline{Q}} \\left(1 + Z_j\\right).$$\n",
     "\n",
-    "Now, we will assume that only a few (polynomially many in $n$) $w_{(Q,\\overline{Q})}$ will be non-zero. Morover we will assume that the set $|(Q,\\overline{Q})|$ is bounded and not too large. This means we can write the cost function as well as the Hamiltonain $H$ as sum of $m$ local terms $\\hat{C}_k$, \n",
+    "Now, we will assume that only a few (polynomially many in $n$) $w_{(Q,\\overline{Q})}$ will be non-zero. Moreover we will assume that the set $|(Q,\\overline{Q})|$ is bounded and not too large. This means we can write the cost function as well as the Hamiltonian $H$ as the sum of $m$ local terms $\\hat{C}_k$, \n",
     "\n",
     "$$ H = \\sum_{k = 1}^n \\hat{C}_k, $$\n",
     "\n",
@@ -75,7 +75,7 @@
    "source": [
     "## 2 Examples: <a id='examples'></a>\n",
     "\n",
-    "We consider 2 examples to illustrate combinatorial optimization problems. We will only implement the first example as  in Qiskit, but provide a sequnce of excersises that give the instructions to implement the second example as well.  \n",
+    "We consider 2 examples to illustrate combinatorial optimization problems. We will only implement the first example as in Qiskit, but provide a sequence of exercises that give the instructions to implement the second example as well.  \n",
     "\n",
     "\n",
     "### 2.1 (weighted) $MAXCUT$\n",
@@ -84,11 +84,11 @@
     "\n",
     "$$C(\\textbf{x}) = \\sum_{i,j = 1}^n w_{ij} x_i (1-x_j).$$\n",
     "\n",
-    "To simplify notation, we assume unifrom weights $ w_{ij} = 1$ for $(i,j) \\in E$. In order to find a solution to this problem on a quantum computer, one needs first to map it to a diagonal  Hamiltonian as discussed above. We write the sum as a sum over edges in the set $(i,j) = E$ \n",
+    "To simplify notation, we assume uniform weights $ w_{ij} = 1$ for $(i,j) \\in E$. In order to find a solution to this problem on a quantum computer, one needs first to map it to a diagonal  Hamiltonian as discussed above. We write the sum as a sum over edges in the set $(i,j) = E$ \n",
     "\n",
     "$$C(\\textbf{x}) = \\sum_{i,j = 1}^n w_{ij} x_i (1-x_j)  = \\sum_{(i,j) \\in E} \\left( x_i (1-x_j) + x_j (1-x_i)\\right)$$\n",
     "\n",
-    "To map is to a spin Hamiltonain we make the assignment $x_i\\rightarrow (1-Z_i)/2$, where $Z_i$ is the Pauli Z operator that has eigenvalues $\\pm 1$ and obtain $X \\rightarrow H$\n",
+    "To map is to a spin Hamiltonian we make the assignment $x_i\\rightarrow (1-Z_i)/2$, where $Z_i$ is the Pauli Z operator that has eigenvalues $\\pm 1$ and obtain $X \\rightarrow H$\n",
     "\n",
     "$$ H = \\sum_{(j,k) \\in E} \\frac{1}{2}\\left(1 - Z_j Z_k \\right).$$\n",
     "\n",
@@ -97,7 +97,7 @@
     "\n",
     "### 2.2 Constraint satisfaction problems and $MAX \\; 3-SAT$.\n",
     "\n",
-    "Another set of examples of a combinatorial optimizatino problem is $3-SAT$. Here the cost function $C(\\textbf{x}) = \\sum_{k = 1}^m c_k(\\textbf{x})$ is a sum of clasuses $c_k(\\textbf{x})$ that constrain the values of $3$ bits of some $\\textbf{x} \\in \\{0,1\\}^n$ that participate in the clause. Consider for instance this example of a $3-SAT$ clause \n",
+    "Another example of a combinatorial optimization problem is $3-SAT$. Here the cost function $C(\\textbf{x}) = \\sum_{k = 1}^m c_k(\\textbf{x})$ is a sum of clauses $c_k(\\textbf{x})$ that constrain the values of $3$ bits of some $\\textbf{x} \\in \\{0,1\\}^n$ that participate in the clause. Consider for instance this example of a $3-SAT$ clause \n",
     "\n",
     "$$ c_1(\\textbf{x}) = (1-x_1)(1-x_3)x_{132} $$\n",
     "\n",
@@ -112,15 +112,15 @@
    "source": [
     "## 3. Approximate optimization algorithms <a id='approximateOPT'></a>\n",
     "\n",
-    "Both the previsously considederd problems $MAXCUT$ and $MAX \\; 3-SAT$ are actually known to be a NP-hard problems [1](#references). In fact it turns out that many combinatorial optimization problems are computationally hard to solve in general. In light of this fact, we can't expect to find a provably efficient algorithm, i.e. an algorithm with polynomial runtime in the problem size, that solves these problems. This also applies to quantum algorithms. One possible approach to such problems is to develop heuristic algortihm that don't have a polynomial runtime gurantee but appear to perform well on some instances of such problems. Another alternative are approximate algorithms. \n",
+    "Both the previously considered problems $MAXCUT$ and $MAX \\; 3-SAT$ are actually known to be a NP-hard problems [1](#references). In fact it turns out that many combinatorial optimization problems are computationally hard to solve in general. In light of this fact, we can't expect to find a provably efficient algorithm, i.e. an algorithm with polynomial runtime in the problem size, that solves these problems. This also applies to quantum algorithms. One possible approach to such problems is to develop heuristic algortihms that don't have a polynomial runtime guarantee but appear to perform well on some instances of such problems. Another alternative are approximate algorithms. \n",
     "\n",
     "Approximate optimization algorithms find approximate solutions to $NP$-hard optimization problems. These algorithms are efficient and provide a provable guarantee on how close the approximate solution is to the actual optimum of the problem. \n",
     "\n",
-    "The guarantee typicall comes in form of an approximation ratio, $\\alpha \\leq 0$. A probabilistic approximate optimization algorithm guarantees that it produces a bit-string $\\textbf{x}^* \\in \\{0,1\\}^n$ so that *with high probability* we have that with a postive $C_{max} = \\max_{\\textbf{x}}C(\\textbf{x})$ \n",
+    "The guarantee typically comes in the form of an approximation ratio, $\\alpha \\leq 0$. A probabilistic approximate optimization algorithm guarantees that it produces a bit-string $\\textbf{x}^* \\in \\{0,1\\}^n$ so that *with high probability* we have that with a postive $C_{max} = \\max_{\\textbf{x}}C(\\textbf{x})$ \n",
     "\n",
     "$$ C_{max} \\geq C(\\textbf{x}^*) \\geq \\alpha C_{max}. $$\n",
     "\n",
-    "For the $MAXCUT$ problem there is a famous approximate algorithm due to Goemans and Williamson [2](#references) . This algorithm is based on an SDP relaxation of the original problem combined with a probabilistic rounding techinque that yields an with high probabilty approxiamte solution $\\textbf{x}^*$ that has an approximation ratio of $\\alpha \\approx 0.868$. This approximation ratio is actually believed to optimal so that we do not expect to see an improvement by using a quantum algorithm."
+    "For the $MAXCUT$ problem there is a famous approximate algorithm due to Goemans and Williamson [2](#references) . This algorithm is based on an SDP relaxation of the original problem combined with a probabilistic rounding technique that yields an with high probabilty approximate solution $\\textbf{x}^*$ that has an approximation ratio of $\\alpha \\approx 0.868$. This approximation ratio is actually believed to optimal so we do not expect to see an improvement by using a quantum algorithm."
    ]
   },
   {
@@ -132,7 +132,7 @@
     "\n",
     "### 4.1 Overview:\n",
     "\n",
-    "We want to find a quantum state $|\\psi_p(\\vec{\\gamma},\\vec{\\beta})\\rangle$, that depends on some real paramters $\\vec{\\gamma},\\vec{\\beta} \\in \\mathbb{R}^p$, which has the property that it maximizes the expectation vaue with repect to the problem Hamiltonian $H$. Given this trial state we search for for parameters $\\vec{\\gamma}^*,\\vec{\\beta}^*$ that maximize $F_p(\\vec{\\gamma},\\vec{\\beta}) = \\langle \\psi_p(\\vec{\\gamma},\\vec{\\beta})|H|\\psi_p(\\vec{\\alpha},\\vec{\\beta})\\rangle$. \n",
+    "We want to find a quantum state $|\\psi_p(\\vec{\\gamma},\\vec{\\beta})\\rangle$, that depends on some real parameters $\\vec{\\gamma},\\vec{\\beta} \\in \\mathbb{R}^p$, which has the property that it maximizes the expectation value with respect to the problem Hamiltonian $H$. Given this trial state we search for parameters $\\vec{\\gamma}^*,\\vec{\\beta}^*$ that maximize $F_p(\\vec{\\gamma},\\vec{\\beta}) = \\langle \\psi_p(\\vec{\\gamma},\\vec{\\beta})|H|\\psi_p(\\vec{\\alpha},\\vec{\\beta})\\rangle$. \n",
     "\n",
     "Once we have such a state and the corresponding parameters we prepare the state $|\\psi_p(\\vec{\\gamma}^*,\\vec{\\beta}^*)\\rangle$ on a quantum computer and measure the state in the $Z$ basis $|x \\rangle = |x_1,\\ldots x_n \\rangle$ to obtain a random outcome $x^*$. \n",
     "\n",
@@ -153,7 +153,7 @@
     "\n",
     "This particular ansatz has the advantage that there exists an explicit choice for the vectors $\\vec{\\gamma}^*,\\vec{\\beta}^*$ such that for $M_p = F_p(\\vec{\\alpha}^*,\\vec{\\beta}^*)$ when we take the limit $\\lim_{p \\rightarrow \\infty} M_p = C_{max}$. This follows by viewing the trial state $|\\psi_p(\\vec{\\gamma},\\vec{\\beta}) \\rangle$ as the state that follows from troterizing the adiabatic evolution with respect to $H$ and the transverse field Hamiltonian $B$, c.f. Ref [3](#references).\n",
     "\n",
-    "Converesely the disatvantage of this trial state is one would typically want a state that has been generated from a quantum cicruit that is not too deep. Here depth is measured with respect to the gates that can be applied directly on the quantum chip. Hence there are other proposal that suggest using Ansatz trial state that are more tailerod to the Hardware of the quantum chip Ref. [4](#references), Ref. [5](#references).\n",
+    "Conversely the disadvantage of this trial state is one would typically want a state that has been generated from a quantum circuit that is not too deep. Here depth is measured with respect to the gates that can be applied directly on the quantum chip. Hence there are other proposals that suggest using Ansatz trial state that are more tailored to the Hardware of the quantum chip Ref. [4](#references), Ref. [5](#references).\n",
     "\n",
     "\n",
     "### 4.2.2 Computing the expectation value <a id=\"section_422\"></a>\n",
@@ -172,33 +172,33 @@
     "\n",
     "$$ \\langle \\psi_1(\\vec{\\gamma},\\vec{\\beta})|\\hat{C}_k|\\psi_1(\\vec{\\alpha},\\vec{\\beta})\\rangle =  \\langle +^n | e^{ i\\gamma_1 H } e^{   i\\beta_1 B } | \\hat{C}_k |  e^{ -i\\beta_1 B } e^{ -i\\gamma_1 H } |+^n\\rangle.$$\n",
     "\n",
-    "Observe that with $B = \\sum_{i = 1}^n X_i$ the unitary $e^{ -i\\beta_1 B }$ is actually a product of single qubit rotations  about $X$ with an angle $\\beta$ for which we will write $X(\\beta)_k = \\exp(i\\beta X_k)$. \n",
+    "Observe that with $B = \\sum_{i = 1}^n X_i$ the unitary $e^{ -i\\beta_1 B }$ is actually a product of single qubit rotations about $X$ with an angle $\\beta$ for which we will write $X(\\beta)_k = \\exp(i\\beta X_k)$. \n",
     "\n",
     "All the individual rotations that don't act on the qubits where $\\hat{C}_k$ is supported commute with $\\hat{C}_k$ and therefore cancel. This does not increase the support of the operator $\\hat{C}_k$. This means that the second set of unitary gates $e^{ -i\\gamma_1 H } = \\prod_{l=1}^m U_l(\\gamma)$ have a large set of gates $U_l(\\gamma) = )e^{ -i\\gamma_1 \\hat{C}_l }$ that commute with the operator $e^{ i\\beta_1 B } \\hat{C}_k  e^{ -i\\beta_1 B }$. The only gates $U_l(\\gamma) = e^{ -i\\gamma_1 \\hat{C}_l }$ that contribute to the expectation value are those which involve qubits in the support of the original $\\hat{C}_k$. \n",
     "\n",
-    "Hence, for bounded degree interaction the support of $e^{ i\\gamma_1 H } e^{   i\\beta_1 B } \\hat{C}_k e^{ -i\\beta_1 B } e^{ -i\\gamma_1 H }$ only expands by an amount given by the degree of the interaction in $H$ and is therefore independent of the sytem size. This means that for these smaller sub problems the expectation values are independedt of $n$ and can be evaluate classcially. The case of a general degree $3$ is considered in [3](#references).\n",
+    "Hence, for bounded degree interaction the support of $e^{ i\\gamma_1 H } e^{   i\\beta_1 B } \\hat{C}_k e^{ -i\\beta_1 B } e^{ -i\\gamma_1 H }$ only expands by an amount given by the degree of the interaction in $H$ and is therefore independent of the system size. This means that for these smaller sub problems the expectation values are independent of $n$ and can be evaluated classically. The case of a general degree $3$ is considered in [3](#references).\n",
     "\n",
-    "This is a general observation,  which means that if we have a problem where the circuit used for the trial state prepartion only increases the support of each term in the Hamiltonian by a constant amount the cost function an be directly evaluated. \n",
+    "This is a general observation,  which means that if we have a problem where the circuit used for the trial state preparation only increases the support of each term in the Hamiltonian by a constant amount the cost function can be directly evaluated. \n",
     "\n",
-    "When this is the case, and only a few parameters $\\beta, \\gamma$ are needed in the pereparation of the trial state,\n",
+    "When this is the case, and only a few parameters $\\beta, \\gamma$ are needed in the preparation of the trial state,\n",
     "these can be found easily by a simple grid search. Furthermore, an exact optimal value of $M_p$ can be used to bound the approximation ratio\n",
     "\n",
     "$$ \\frac{M_p}{C_{max}} \\geq \\alpha $$\n",
     "\n",
-    "to obtain an estimate of $\\alpha$. For this case the QAOA algorithm has the same characteristcs as a conventional approximate optimization algorithm that comes with a garanteed approximation ratio that can be obtained with polynomail efficiency in the problem size.\n",
+    "to obtain an estimate of $\\alpha$. For this case the QAOA algorithm has the same characteristics as a conventional approximate optimization algorithm that comes with a guaranteed approximation ratio that can be obtained with polynomial efficiency in the problem size.\n",
     "\n",
     "\n",
     "#### Evaluation on a quantum computer\n",
     "\n",
-    "When the quantum circuit becomes to deep to be evalauted classically, or when the connectivity of the Problem Hamiltonian is too high we can resort to other means of estimating the expectation value. This involves directly estimating $F_p(\\vec{\\gamma},\\vec{\\beta})$ on the quantum computer. The approach here follows the path of the conventional expectation value estimateion as used in -CITE - VQE, where a trial state $| \\psi(\\vec{\\gamma},\\vec{\\beta})$ is prepared directly on the quantum computer and the expectation value is obtained from sampling.\n",
+    "When the quantum circuit becomes too deep to be evalauted classically, or when the connectivity of the Problem Hamiltonian is too high we can resort to other means of estimating the expectation value. This involves directly estimating $F_p(\\vec{\\gamma},\\vec{\\beta})$ on the quantum computer. The approach here follows the path of the conventional expectation value estimation as used in -CITE - VQE, where a trial state $| \\psi(\\vec{\\gamma},\\vec{\\beta})$ is prepared directly on the quantum computer and the expectation value is obtained from sampling.\n",
     "\n",
-    "Since QAOA  has a diagonal Hamiltonain $H$ it is actually straight forward to estimate the expectation value. We only need to obtain samples from the trial state in the computational basis. Recall that $H = \\sum_{x \\in \\{0,1\\}^n} C(x) |x \\rangle\\langle x|$ so that we can obtain the sampling estimate of \n",
+    "Since QAOA  has a diagonal Hamiltonian $H$ it is actually straight forward to estimate the expectation value. We only need to obtain samples from the trial state in the computational basis. Recall that $H = \\sum_{x \\in \\{0,1\\}^n} C(x) |x \\rangle\\langle x|$ so that we can obtain the sampling estimate of \n",
     "\n",
     "$$ \\langle \\psi_p(\\vec{\\gamma},\\vec{\\beta})|H|\\psi_p(\\vec{\\alpha},\\vec{\\beta})\\rangle = \\sum_{x \\in \\{0,1\\}^n} C(x) |\\langle x| \\psi_p(\\vec{\\gamma},\\vec{\\beta}) \\rangle |^2$$\n",
     "\n",
-    "by repreated single qubit measurements of the state $| \\psi_p(\\vec{\\gamma},\\vec{\\beta}) \\rangle $ in the $Z$ - basis. For every bit - string $x$ obtained from the distribution $|\\langle x| \\psi_p(\\vec{\\gamma},\\vec{\\beta}) \\rangle |^2$ we evaluate the cost function $C(x)$ and avarage it over the the total number of samples. The resulting empirical avarage approximates the expectation value up to an additive sampling error that lies within the varaince of the state. The variance will be discussed below.\n",
+    "by repeated single qubit measurements of the state $| \\psi_p(\\vec{\\gamma},\\vec{\\beta}) \\rangle $ in the $Z$ - basis. For every bit - string $x$ obtained from the distribution $|\\langle x| \\psi_p(\\vec{\\gamma},\\vec{\\beta}) \\rangle |^2$ we evaluate the cost function $C(x)$ and average it over the total number of samples. The resulting empirical avarage approximates the expectation value up to an additive sampling error that lies within the variance of the state. The variance will be discussed below.\n",
     "\n",
-    "With access to the expectaion value, we can now run a classical optimization algorithm, such as [6](#references),\n",
+    "With access to the expectation value, we can now run a classical optimization algorithm, such as [6](#references),\n",
     "to optimize the $F_p$.\n",
     "\n",
     "While this approach does not lead to an a-priori approximation guaratee for $x^*$, the optimzed function value \n",
@@ -226,7 +226,7 @@
     "$\\langle \\psi_p(\\vec{\\gamma},\\vec{\\beta})|\\hat{C}_k \\hat{C}_l |\\psi_p(\\vec{\\alpha},\\vec{\\beta})\\rangle \\leq \\tilde{C}^2$. \n",
     "\n",
     "\n",
-    "This means that the variance of any expetation $F_p(\\vec{\\gamma},\\vec{\\beta})$ is bounded by $m^2 \\tilde{C}^2$. Hence this in particular applies for $M_p$. Furthermore if $m$ only grows polynomially in the number of qubits $n$, we know that taking polynomially growing number of samples $s = O\\left(\\frac{\\tilde{C}^2 m^2}{\\epsilon^2}\\right)$ from $|\\langle x| \\psi_p(\\vec{\\gamma},\\vec{\\beta}) \\rangle |^2$ will be sufficient to obtain a $x^*$ that leads to an $C(x^*)$ that will be close to $M_p$."
+    "This means that the variance of any expectation $F_p(\\vec{\\gamma},\\vec{\\beta})$ is bounded by $m^2 \\tilde{C}^2$. Hence this in particular applies for $M_p$. Furthermore if $m$ only grows polynomially in the number of qubits $n$, we know that taking polynomially growing number of samples $s = O\\left(\\frac{\\tilde{C}^2 m^2}{\\epsilon^2}\\right)$ from $|\\langle x| \\psi_p(\\vec{\\gamma},\\vec{\\beta}) \\rangle |^2$ will be sufficient to obtain a $x^*$ that leads to an $C(x^*)$ that will be close to $M_p$."
    ]
   },
   {
@@ -332,12 +332,12 @@
    "source": [
     "### 5.2 Optimal trial state parameters<a id=\"implementation_sec52\"></a>\n",
     "\n",
-    "In this example we consider the case for $p = 1$, i.e. only layer of gates. The expectation value $F_1(\\gamma,\\beta) = \\langle \\psi_1(\\beta,\\gamma)|H|\\psi_1{\\beta,\\gamma}$ can be calculated analytically for this simple setting. Let us discuss the steps explicityly for the Hamiltonian $H = \\sum_{(j,k) \\in E} \\frac{1}{2}\\left(1 - Z_i Z_k)\\right)$. Due to the linearity of the expectation value we can compute the expectaion value for the edges individually\n",
+    "In this example we consider the case for $p = 1$, i.e. only layer of gates. The expectation value $F_1(\\gamma,\\beta) = \\langle \\psi_1(\\beta,\\gamma)|H|\\psi_1{\\beta,\\gamma}$ can be calculated analytically for this simple setting. Let us discuss the steps explicitly for the Hamiltonian $H = \\sum_{(j,k) \\in E} \\frac{1}{2}\\left(1 - Z_i Z_k)\\right)$. Due to the linearity of the expectation value we can compute the expectation value for the edges individually\n",
     "\n",
     "$$f_{(i,k)}(\\beta,\\alpha) =  \\langle \\psi_1(\\gamma,\\beta)|\\;\\frac{1}{2}\\left(1 - Z_i Z_k)\\right)\\;|\\psi_1(\\gamma,\\beta)\\rangle. $$\n",
     "\n",
     "For the butterfly graph as plotted above, we observe that there are only two kinds of edges $A = \\{(0,1),(3,4)\\}$ and \n",
-    "$B = \\{(0,2),(1,2),(2,3),(2,4)\\}$. The edges is $A$ only have two neighboring edges, while the edges in $B$ have four. You can convince yourself that we only need to compute the expectation of a single edge in each set since the other expectation values will be the same. This means that we can compute $F_1(\\gamma,\\beta) = 2 f_A(\\gamma,\\beta) + 4f_B(\\gamma,\\beta)$ by evaluating only computing two expectation values. Note, that following the argument as outlined in [section 4.2.2](#section_422), all the gates that do not intersect with the Pauli opertor $Z_0Z_1$ or $Z_0Z_2$ commute and cancel out so that we only need to compute\n",
+    "$B = \\{(0,2),(1,2),(2,3),(2,4)\\}$. The edges in $A$ only have two neighboring edges, while the edges in $B$ have four. You can convince yourself that we only need to compute the expectation of a single edge in each set since the other expectation values will be the same. This means that we can compute $F_1(\\gamma,\\beta) = 2 f_A(\\gamma,\\beta) + 4f_B(\\gamma,\\beta)$ by evaluating only computing two expectation values. Note, that following the argument as outlined in [section 4.2.2](#section_422), all the gates that do not intersect with the Pauli opertor $Z_0Z_1$ or $Z_0Z_2$ commute and cancel out so that we only need to compute\n",
     "\n",
     "$$f_A(\\gamma,\\beta) = \\frac{1}{2}\\left(1 - \\langle +^3|U_{21}(\\gamma)U_{02}(\\gamma)U_{01}(\\gamma)X_{0}(\\beta)X_{1}(\\beta)\\;Z_0Z_1\\; X^\\dagger_{1}(\\beta)X^\\dagger_{0}(\\beta)U^\\dagger_{01}(\\gamma)U^\\dagger_{02}(\\gamma)U^\\dagger_{12}(\\gamma)  | +^3 \\rangle \\right)$$\n",
     "\n",
@@ -354,7 +354,7 @@
     "\n",
     "$$f_B(\\gamma,\\beta) = \\frac{1}{2}\\left(1 - sin^2(2\\beta)sin^2(2\\gamma)cos^2(4\\gamma) - \\frac{1}{4}sin(4\\beta)sin(4\\gamma)(1+cos^2(4\\gamma))\\right) $$\n",
     "\n",
-    "These results can now be combined as discribed above, and we the expectation value is therefore given by\n",
+    "These results can now be combined as described above, and the expectation value is therefore given by\n",
     "\n",
     "$$ F_1(\\gamma,\\beta) = 3 - \\left(sin^2(2\\beta)sin^2(2\\gamma)- \\frac{1}{2}sin(4\\beta)sin(4\\gamma)\\right)\\left(1  + cos^2(4\\gamma)\\right),$$\n",
     "\n",
@@ -420,7 +420,7 @@
     "\n",
     "plt.show()\n",
     "\n",
-    "#The smallest paramters and the expectation can be extracted\n",
+    "#The smallest parameters and the expectation can be extracted\n",
     "print('\\n --- OPTIMAL PARAMETERS --- \\n')\n",
     "print('The maximal expectation value is:  M1 = %.03f' % np.amax(F1))\n",
     "print('This is attained for gamma = %.03f and beta = %.03f' % (gamma,beta))"
@@ -432,7 +432,7 @@
    "source": [
     "### 5.3 Quantum circuit<a id=\"implementation_sec53\"></a>\n",
     "\n",
-    "With these paramters we can now construct the circuit that prepares the trial state for the Graph\n",
+    "With these parameters we can now construct the circuit that prepares the trial state for the Graph\n",
     "or the Graph $G = (V,E)$ described above with vertex set $V = \\{0,1,2,3,4\\}$ and the edges are $E = \\{(0,1),(0,2),(1,2),(3,2),(3,4),(4,2)\\}$. The circuit is going to requite $n = 5$ qubits and we prepare the state \n",
     "\n",
     "$$ |\\psi_1(\\gamma ,\\beta)\\rangle = e^{ -i\\beta B } e^{ -i\\gamma H } |+\\rangle^n.  $$\n",
@@ -442,7 +442,7 @@
     " - We first implement 5 - Hadamard $H$ gates to generate the unifrom superposition.\n",
     " \n",
     "\n",
-    " - This is follow by $6$ Ising type gates $U_{k,l}(\\gamma)$ with angle $\\gamma$ along the edges $(k,l) \\in E$. This gate can be extressed in terms of the native Qiskit gates as\n",
+    " - This is follow by $6$ Ising type gates $U_{k,l}(\\gamma)$ with angle $\\gamma$ along the edges $(k,l) \\in E$. This gate can be expressed in terms of the native Qiskit gates as\n",
     "\n",
     "  $$ U_{k,l}(\\gamma) = C_{u1}(-2\\gamma)_{k,l}u1(\\gamma)_k u1(\\gamma)_l$$\n",
     "  \n",
@@ -450,7 +450,7 @@
     " - Lastly we apply single qubit $X$ rotations $X_k(\\beta)$ for every vertex $k \\in V$ with $\\beta$ as angle. This gate directly parametrized as $X_k(\\beta) = R_x(2\\beta)_k$ in Qiskit.\n",
     " \n",
     "\n",
-    " - In the last srep we measure the qubits in the computational basis, i.e. we perfrom a $Z$ - measurement and record the resulting bit-string $x \\in \\{0,1\\}^5$."
+    " - In the last step we measure the qubits in the computational basis, i.e. we perfrom a $Z$ - measurement and record the resulting bit-string $x \\in \\{0,1\\}^5$."
    ]
   },
   {
@@ -471,7 +471,7 @@
     }
    ],
    "source": [
-    "# preapre the quantum and classical resisters\n",
+    "# prepare the quantum and classical resisters\n",
     "QAOA = QuantumCircuit(len(V), len(V))\n",
     "\n",
     "# apply the layer of Hadamard gates to all qubits\n",
@@ -506,7 +506,7 @@
     "\n",
     "Finally, we need a routine to compute the cost function value from the bit string. \n",
     "This is necessary to decide whether we have found a \"good candidate\" bitstring $x$ but could also \n",
-    "be used to estimate the expectation value $F_1(\\gamma,\\beta)$ in settings where the expectation value can not be evlautated directly."
+    "be used to estimate the expectation value $F_1(\\gamma,\\beta)$ in settings where the expectation value can not be evalutated directly."
    ]
   },
   {
@@ -581,7 +581,7 @@
     "\n",
     "- Compute the mean energy and check whether it agrees with the theoretical prediction\n",
     "- Report the sampled bitstring $x^*$ with the largest observed cost function $C(x^*)$ \n",
-    "- Plot the Historgram of the energies to see whether is indeed concentrates around the prediceted mean"
+    "- Plot the Histogram of the energies to see whether it indeed concentrates around the predicted mean"
    ]
   },
   {
@@ -886,7 +886,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "0. The QAOA algortihm produces a bit string, is this string the optimal solution for this graph? Compare the experiemental results from the superconducting chip with the results from the local QASM simulation.\n",
+    "0. The QAOA algortihm produces a bit string, is this string the optimal solution for this graph? Compare the experimental results from the superconducting chip with the results from the local QASM simulation.\n",
     "\n",
     "\n",
     "1. We have computed the cost function $F_1$  analytically in [section 5.2](#implementation_sec52). Verify the steps and compute $f_A(\\gamma,\\beta)$ as well $f_B(\\gamma,\\beta)$. \n",
@@ -896,17 +896,17 @@
     "\n",
     "      -Write a routine to estimate the expectation value $F_1(\\gamma,\\beta)$ from the samples obtained in the result (hint: use the function cost_function_C(x,G) from [section 5.4](#implementation_sec54) and the evaluation of the data in both section [5.a / 5.b](#implementationsim))\n",
     "       \n",
-    "      -Use an optimizaion routine,e.g. SPSA from the VQE example in this tutorial, to optimize the parmeters in the sampled $F_1(\\gamma,\\beta)$ numerically. Do you find the same values for $\\gamma^*,\\beta^*$ ?\n",
+    "      -Use an optimizaion routine,e.g. SPSA from the VQE example in this tutorial, to optimize the parameters in the sampled $F_1(\\gamma,\\beta)$ numerically. Do you find the same values for $\\gamma^*,\\beta^*$ ?\n",
     "\n",
     "\n",
-    "2. The Trial circuit in [section 5.3](#implementation_sec53) corresponds to depth $p=1$ and was directly aimed at being compatible with the Hardware.\n",
+    "3. The Trial circuit in [section 5.3](#implementation_sec53) corresponds to depth $p=1$ and was directly aimed at being compatible with the Hardware.\n",
     "\n",
-    "    -Use the routine from exercise 2 to evaluate the the cost functions $F_p(\\gamma,\\beta)$ for $p=2,3$. What do you expect to see in the actual Hardware?\n",
+    "    -Use the routine from exercise 2 to evaluate the cost functions $F_p(\\gamma,\\beta)$ for $p=2,3$. What do you expect to see in the actual Hardware?\n",
     "    \n",
     "    -Generalize this class of trial state to other candidate wave fuctions, such as the Hardware efficient ansatz of Ref. [4](#references).\n",
     "    \n",
     "\n",
-    "3. Consder an example of $MAX \\;\\; 3-SAT$ as discussed in the example section and modify the function cost_function_C(c,G) from [section 5.4](#implementation_sec54) you have used to compute $F_p$ accordingly. Run the QAOA algorithm for this instance of $MAX \\; 3-SAT$ using the hardware efficient algorithm and analyze the results. "
+    "4. Consder an example of $MAX \\;\\; 3-SAT$ as discussed in the example section and modify the function cost_function_C(c,G) from [section 5.4](#implementation_sec54) you have used to compute $F_p$ accordingly. Run the QAOA algorithm for this instance of $MAX \\; 3-SAT$ using the hardware efficient algorithm and analyze the results. "
    ]
   },
   {


### PR DESCRIPTION
## Description of Issue (if Applicable)
Several small typos in the QAOA section of the textbook.

## What Changes Were Made?
Corrections of these typos.

## Anything Else We Should Know 
I was reading through this section of the textbook and noticed several typos.
As it was open source I thought to go through quickly and make the changes.