### PR TITLE
Fix svg width

### DIFF
--- a/_sass/components/_components.images.scss
+++ b/_sass/components/_components.images.scss
@@ -1,0 +1,4 @@
+svg {
+  width: 100%;
+  height: auto;
+}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -26,4 +26,5 @@ $hamburger-types: (arrowalt);
 @import 'components/components.page__footer';
 @import 'components/components.interact-button';
 @import 'components/components.thebelab';
+@import 'components/components.images';
 @import 'components/components.search';


### PR DESCRIPTION
Fixes #226 

Now SVGs occupy 100% of the container, no more. A potential problemI've detected is that the reading area is too small.