### PR TITLE
4.1.1HLL section C typo: QPE is discribed in chapter 3 not 4

### DIFF
--- a/content/ch-applications/hhl_tutorial.ipynb
+++ b/content/ch-applications/hhl_tutorial.ipynb
@@ -113,7 +113,7 @@
     "    \n",
     "### C. Quantum Phase Estimation (QPE) within HHL <a id='qpe'></a>\n",
     "\n",
-    "Quantum Phase Estimation is described in more detail in Chapter 4. However, since this quantum procedure is at the core of the HHL algorithm, we recall here the definition. Roughly speaking, it is a quantum algorithm which, given a unitary $U$ with eigenvector $|\\psi\\rangle_{m}$ and eigenvalue $e^{2\\pi i\\theta}$, finds $\\theta$. We can formally define this as follows.\n",
+    "Quantum Phase Estimation is described in more detail in Chapter 3. However, since this quantum procedure is at the core of the HHL algorithm, we recall here the definition. Roughly speaking, it is a quantum algorithm which, given a unitary $U$ with eigenvector $|\\psi\\rangle_{m}$ and eigenvalue $e^{2\\pi i\\theta}$, finds $\\theta$. We can formally define this as follows.\n",
     "\n",
     "**Definition:** Let $U\\in\\mathbb{ C }^{2^{m}\\times 2^{m}}$ be unitary and let $|\\psi\\rangle_{m}\\in\\mathbb{ C }^{2^{m}}$ be one of its eigenvectors with respective eigenvalue $e^{2\\pi i\\theta}$. The **Quantum Phase Estimation** algorithm, abbreviated **QPE**, takes as inputs the unitary gate for $U$ and the state $|0\\rangle_{n}|\\psi\\rangle_{m}$ and returns the state $|\\tilde{\\theta}\\rangle_{n}|\\psi\\rangle_{m}$. Here $\\tilde{\\theta}$ denotes a binary approximation to $\\theta$ and the $n$ subscript denotes it has been truncated to $n$ digits.\t\n",
     "$$\n",


### PR DESCRIPTION
<!--- This is a rough template to help make sure 
      you don't miss anything out, don't worry about
      adhering strictly to it --->
## Description of Issue (if Applicable)
section C typo: QPE is discribed in chapter 3 not 4

Fixes #your_issue_number_here

## What Changes Were Made?
4 replaced by 3

## How Was This Tested?

Please provide any screenshots if applicable.

## Anything Else We Should Know 
