### PR TITLE
4.1.1hhl 4B typo an instance

### DIFF
--- a/content/ch-applications/hhl_tutorial.ipynb
+++ b/content/ch-applications/hhl_tutorial.ipynb
@@ -498,7 +498,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The code below takes as inputs our circuit, the real hardware backend and the set of qubits we want to use, and returns and instance that can be run on the specified device. Creating the circuits with $3$ and $5$ CNOTs is the same but calling the transpile method with the right quantum circuit.\n",
+    "The code below takes as inputs our circuit, the real hardware backend and the set of qubits we want to use, and returns an instance that can be run on the specified device. Creating the circuits with $3$ and $5$ CNOTs is the same but calling the transpile method with the right quantum circuit.\n",
     "\n",
     "Real hardware devices need to be recalibrated regularly, and the fidelity of a specific qubit or gate can change over time. Furthermore, different chips have different connectivities. If we try to run a circuit that performs a two-qubit gate between two qubits that are not connected on the specified device, the transpiler will add SWAP gates. Therefore it is good practice to check with the IBM Q Experience webpage<sup>[7](#qexperience)</sup> before running the following code and choose a set of qubits with the right connectivity and lowest error rates at the given time."
    ]

--- a/content/ch-applications/hhl_tutorial.ipynb
+++ b/content/ch-applications/hhl_tutorial.ipynb
@@ -498,7 +498,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The code below takes as inputs our circuit, the real hardware backend and the set of qubits we want to use, and returns an instance that can be run on the specified device. Creating the circuits with $3$ and $5$ CNOTs is the same but calling the transpile method with the right quantum circuit.\n",
+    "The code below takes as inputs our circuit, the real hardware backend and the set of qubits we want to use, and returns and instance that can be run on the specified device. Creating the circuits with $3$ and $5$ CNOTs is the same but calling the transpile method with the right quantum circuit.\n",
     "\n",
     "Real hardware devices need to be recalibrated regularly, and the fidelity of a specific qubit or gate can change over time. Furthermore, different chips have different connectivities. If we try to run a circuit that performs a two-qubit gate between two qubits that are not connected on the specified device, the transpiler will add SWAP gates. Therefore it is good practice to check with the IBM Q Experience webpage<sup>[7](#qexperience)</sup> before running the following code and choose a set of qubits with the right connectivity and lowest error rates at the given time."
    ]
@@ -529,7 +529,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The next step is to create the extra circuits used to mitigate the redaout errors<sup>[3](#readouterr)</sup>."
+    "The next step is to create the extra circuits used to mitigate the readout errors<sup>[3](#readouterr)</sup>."
    ]
   },
   {


### PR DESCRIPTION
<!--- This is a rough template to help make sure 
      you don't miss anything out, don't worry about
      adhering strictly to it --->
## Description of Issue (if Applicable)
2 typos:
4.1.1hhl 4B typo "and instance"
4.1.1hhl 4B typo "redaout"
Fixes #your_issue_number_here

## What Changes Were Made?
1. "and instance" changed to  "an instance"
2. "redaout" to "readout"
## How Was This Tested?

Please provide any screenshots if applicable.

## Anything Else We Should Know 
