### PR TITLE
Fix precedence between Thebelab and theme CSS

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,7 @@
   <script type="application/ld+json">
   {% include metadata.json %}
   </script>
-  <link rel="stylesheet" href="{{ site.css_url | relative_url }}/styles.css">
+  <link id="theme-style" rel="stylesheet" href="{{ site.css_url | relative_url }}/styles.css">
 
   <!-- <link rel="manifest" href="/manifest.json"> -->
   <!-- <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#efae0a"> -->
@@ -48,7 +48,7 @@
   <!-- Turbolinks were causing problems with equations in details tags, I have
 	  removed them for now as I didn't notice a siginificant difference in
 	  loading time, but maybe someone more knowledgeable than me can sort
-	  the problem properly and re-enable -Frank 
+	  the problem properly and re-enable -Frank
   <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" async></script>
   <meta name="turbolinks-cache-control" content="no-cache">
   -->
@@ -77,7 +77,7 @@
 
   <!-- Load custom user CSS and JS  -->
   <script src="{{ site.custom_static_url | relative_url }}/custom.js" async></script>
-  <link rel="stylesheet" href="{{ site.custom_static_url | relative_url }}/custom.css">
+  <link id="custom-style" rel="stylesheet" href="{{ site.custom_static_url | relative_url }}/custom.css">
 
   <!-- Update interact links w/ REST param, is defined in includes so we can use templates -->
   {% include js/interact-update.html %}

--- a/_includes/js/thebelab.html
+++ b/_includes/js/thebelab.html
@@ -4,12 +4,29 @@
 <!-- Display Thebelab button in each code cell -->
 {% include js/thebelab-cell-button.html %}
 
-<script src="{{ site.vendor_url | relative_url }}/thebelab/index.js" async></script>
 <script>
+    /**
+     * Thebelab loads "reset CSS" after the theme styles load and so,
+     * it invalidates part of the theme rules. To make the theme CSS to take
+     * the correct precedence, we listen for Thebelab to finish loading, then
+     * relocate the theme CSS and start Thebelab.
+     */
+    const thebeLabScript = document.createElement('script');
+    thebeLabScript.src = "{{ site.vendor_url | relative_url }}/thebelab/index.js"
+    thebeLabScript.async = true
+    thebeLabScript.onload = () => {
+        setTimeout(() => {
+            document.head.append(
+                ...document.querySelectorAll('#theme-style, #custom-style'))
+        })
+        initFunction(initThebelab)
+    }
+    document.head.append(thebeLabScript);
+
     /**
      * Add attributes to Thebelab blocks
      */
-    const initThebelab = () => {
+    function initThebelab() {
         const addThebelabToCodeCells = () => {
             console.log("Adding thebelab to code cells...");
             // If Thebelab hasn't loaded, wait a bit and try again. This
@@ -132,9 +149,6 @@
             return getInputCell(parent);
         }
     }
-
-    // Initialize Thebelab
-    initFunction(initThebelab);
 
 // Helper function to munge the language name
 var detectLanguage = (language) => {


### PR DESCRIPTION
# Description of Issue

Thebelab loads and place CSS at the bottom of the `<head>` tag and overrides some properties of Jupyter Book, breaking the layout.

## What Changes Were Made?

This PR modifies the way in which Thebelab is loaded to wait for all its styles to be loaded, then relocate Jupyter Book CSS sheets so they get the correct precedence.