### PR TITLE
Corrected definition of Pauli-Y matrix

### DIFF
--- a/content/ch-states/single-qubit-gates.ipynb
+++ b/content/ch-states/single-qubit-gates.ipynb
@@ -4211,7 +4211,7 @@
     "\n",
     "$$ Y = \\begin{bmatrix} 0 & -i \\\\ i & 0 \\end{bmatrix} \\quad\\quad\\quad\\quad Z = \\begin{bmatrix} 1 & 0 \\\\ 0 & -1 \\end{bmatrix} $$\n",
     "\n",
-    "$$ Y = i|0\\rangle\\langle1| - i|1\\rangle\\langle0| \\quad\\quad Z = |0\\rangle\\langle0| - |1\\rangle\\langle1| $$\n",
+    "$$ Y = -i|0\\rangle\\langle1| + i|1\\rangle\\langle0| \\quad\\quad Z = |0\\rangle\\langle0| - |1\\rangle\\langle1| $$\n",
     "\n",
     "And, unsurprisingly, they also respectively perform rotations by $\\pi$ around the y and z-axis of the Bloch sphere.\n",
     "\n",
@@ -9788,7 +9788,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--- This is a rough template to help make sure 
      you don't miss anything out, don't worry about
      adhering strictly to it --->
## Description of Issue (if Applicable)
The mathematical definition of Pauli-Ymatrix (in terms of outer product) was incorrect, i.e. the signs were flipped.

## What Changes Were Made?
Changed the signs of the relevant terms.
## How Was This Tested?
With a pen and a piece of paper.
Please provide any screenshots if applicable.

## Anything Else We Should Know 
