### PR TITLE
Ensure the engine script is initialized after the engine is loaded

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -83,7 +83,6 @@
   {% include js/interact-update.html %}
 
   <!-- Lunr search code - will only be executed on the /search page -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.6/lunr.min.js" async></script>
   <script>{% include search/lunr/lunr-en.js %}</script>
 
   <!-- Load JS that depends on site variables -->

--- a/_includes/search/lunr/lunr-en.js
+++ b/_includes/search/lunr/lunr-en.js
@@ -81,4 +81,6 @@ var initQuery = function() {
   });
 };
 
-initFunction(initQuery);
+loadAsyncScript('https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.6/lunr.min.js')
+.then(() => initFunction(initQuery))
+.catch((err) => console.error('Cannot load lunr search engine:', err))

--- a/_includes/segment.html
+++ b/_includes/segment.html
@@ -23,19 +23,8 @@
     }
   }
 
-  window._analyticsReady = window._analyticsReady || new Promise((resolve) => {
-    const script = document.createElement('script')
-    script.async = true
-    script.src = 'https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js'
-    document.head.appendChild(script)
-    script.onload = resolve
-    script.onerror = (err) => {
-      console.warn('Error loading Bluemix Analytics script:', err)
-      resolve()
-    }
-  })
-
-  window._analyticsReady.then(() => {
+  loadAsyncScript('https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js')
+  .then(() => {
     if (!window.bluemixAnalytics || !window.digitalData) { return }
 
     const category = window.digitalData.page.pageInfo.analytics.category
@@ -47,6 +36,9 @@
       productTitle: productTitle,
       title: document.title
     })
+  })
+  .catch((err) => {
+    console.warn('Error loading Bluemix Analytics script:', err)
   })
 
   window.trackCta = (action) => {

--- a/assets/js/page/dom-update.js
+++ b/assets/js/page/dom-update.js
@@ -15,3 +15,23 @@ initFunction = function(myfunc) {
   runWhenDOMLoaded(myfunc);
   document.addEventListener('turbolinks:load', myfunc);
 };
+
+// Helper function to load scripts asynchronously. Return a promise resolved
+// when the script is loaded.
+window._asyncScripts = {}
+loadAsyncScript = function(url) {
+  if (!window._asyncScripts.hasOwnProperty(url)) {
+    window._asyncScripts[url] = new Promise((resolve, reject) => {
+      const script = document.createElement('script')
+      script.async = true
+      script.src = url
+      document.head.appendChild(script)
+      script.onload = resolve
+      script.onerror = (err) => {
+        console.error('Error loading async script:', url)
+        reject(err)
+      }
+    })
+  }
+  return window._asyncScripts[url]
+};


### PR DESCRIPTION
Fixes #325

## What Changes Were Made?

Factor out a helper function to asynchronously load scripts and use it to coordinate the initialization of some libraries such as lunr, the search engine.

## How Was This Tested?

Compared errors in the console before and after the modification.