### PR TITLE
fixed link to Beauregard reference

### DIFF
--- a/content/ch-algorithms/shor.ipynb
+++ b/content/ch-algorithms/shor.ipynb
@@ -4157,7 +4157,7 @@
    "source": [
     "## 6. References\n",
     "\n",
-    "1. Stephane Beauregard, _Circuit for Shor's algorithm using 2n+3 qubits,_ [arXiv:quant-ph/0205095](arXiv:quant-ph/0205095)\n",
+    "1. Stephane Beauregard, _Circuit for Shor's algorithm using 2n+3 qubits,_ [arXiv:quant-ph/0205095](https://arxiv.org/abs/quant-ph/0205095)\n",
     "\n",
     "2. M. Nielsen and I. Chuang, _Quantum Computation and Quantum Information,_ Cambridge Series on Information and the Natural Sciences (Cambridge University Press, Cambridge, 2000). (Page 633)"
    ]


### PR DESCRIPTION
<!--- This is a rough template to help make sure 
      you don't miss anything out, don't worry about
      adhering strictly to it --->
## Description of Issue (if Applicable)
Link to Beauregard's paper in References was not working.
Fixes #your_issue_number_here

## What Changes Were Made?
A link was provided (following the way it was done in the Bernstein-Vazirani chapter > References).
## How Was This Tested?
Now clicking on the link takes you to the arxiv as desired
Please provide any screenshots if applicable.

## Anything Else We Should Know 
